### PR TITLE
V0.5.2: Graph function and UI updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ It is designed as a focused research tool for:
 - interactive patch selection,
 - patch saving,
 - patch-wise volumetric computation (e.g., normalization, standardization, filtering, etc.),
-- orthogonal **MIP / MinIP** inspection of selected, modified patches,
+- orthogonal **MIP / MinIP** inspection of selected, modified patches, optionally
+  restricted to a loaded file-backed segmentation mask,
 - projection-graph editing with nodes, straight or curved edges, and physical-spacing-aware angle measurement,
 - controlled local IPC and `mipview-ctl` commands for viewer, patch, annotation, projection, and graph workflows.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 It is designed as a focused research tool for:
 
 - ITK-SNAP inspired image viewing,
-- segmentation overlay inspection,
+- multi-label segmentation overlay inspection with deterministic per-label colors,
 - voxel-space annotation with editable label masks,
 - interactive patch selection,
 - patch saving,

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ It is designed as a focused research tool for:
 - patch saving,
 - patch-wise volumetric computation (e.g., normalization, standardization, filtering, etc.),
 - orthogonal **MIP / MinIP** inspection of selected, modified patches, optionally
-  restricted to a loaded file-backed segmentation mask,
+  restricted to a loaded file-backed segmentation mask, with opt-in MIP of the
+  active file or annotation segmentation overlay,
 - projection-graph editing with nodes, straight or curved edges, and physical-spacing-aware angle measurement,
 - controlled local IPC and `mipview-ctl` commands for viewer, patch, annotation, projection, and graph workflows.
 
@@ -125,6 +126,7 @@ The current codebase is organized around a small top-level `mipview` package:
     │   ├── geometry.py
     │   ├── measurement.py
     │   ├── model.py
+    │   ├── spatial.py
     │   └── state.py
     ├── io/
     │   └── nifti_io.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mipview"
-version = "0.5.1"
+version = "0.5.2"
 description = "A lightweight Linux-first NIfTI viewer for patch-based inspection workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mipview/control/README.md
+++ b/src/mipview/control/README.md
@@ -434,15 +434,18 @@ mipview-ctl projection save axial ./patch_axial_minip.png --annotation-preview
 ### Graph commands
 
 Graph commands target an open patch window by the session ID reported in
-`viewer.export_state` under `graph_sessions`. Coordinates are oriented 2D
-projection indices. The target orientation must be showing MIP/MinIP and Graph
-mode must be active for mutation commands.
+`viewer.export_state` under `graph_sessions`. The graph is shared across all
+three projections and stored in patch-local source voxel space. `add-node` uses
+oriented 2D projection indices and resolves depth from the current finite
+MIP/MinIP extremum; `add-voxel-node` accepts explicit patch-local `(x, y, z)`
+coordinates. Graph mode must be active for mutation commands.
 
 ```bash
 mipview-ctl graph status SESSION_ID
 mipview-ctl graph activate SESSION_ID
 mipview-ctl graph display SESSION_ID --opacity 0.75 --node-size 3
 mipview-ctl graph add-node SESSION_ID axial 12 18
+mipview-ctl graph add-voxel-node SESSION_ID 12 18 7
 mipview-ctl graph add-edge SESSION_ID axial 1 2
 mipview-ctl graph curve-edge SESSION_ID axial 1 2 18.5 24.0
 mipview-ctl graph straighten-edge SESSION_ID axial 1 2
@@ -456,17 +459,20 @@ mipview-ctl graph exit SESSION_ID
 
 The matching direct commands are `graph.status`, `graph.activate`,
 `graph.set_display`, `graph.add_node`, `graph.delete_node`, `graph.add_edge`,
-`graph.delete_edge`, `graph.curve_edge`, `graph.straighten_edge`, `graph.split_edge`,
-`graph.calculate_angle`, and `graph.clear_angle`.
+`graph.add_voxel_node`, `graph.delete_edge`, `graph.curve_edge`,
+`graph.straighten_edge`, `graph.split_edge`, `graph.calculate_angle`, and
+`graph.clear_angle`.
 
 Curve controls use floating-point oriented projection coordinates and must be
-finite and inside the projection plane. Angle node IDs are ordered as vector 1
-source/target followed by vector 2 source/target. Both vectors use the command's
+finite and inside the projection plane. They update a shared 3D control point by
+preserving the coordinate hidden by the selected view. Angle node IDs are ordered
+as vector 1 source/target followed by vector 2 source/target. Both vectors use the command's
 single orientation, and calculation scales their horizontal and vertical
 components by physical in-plane voxel spacing before evaluating the unsigned
-angle. Graph status includes curve controls, active tool/selection state, both
-directed vectors, and `angle_degrees`. Graph sessions are in-memory only and
-disappear when their patch window closes.
+angle. Graph status includes authoritative patch voxels, full-image voxels when
+patch bounds are known, projections in all orientations, 3D curve controls,
+active tool/selection state, both directed vectors, and `angle_degrees`. Graph
+sessions are in-memory only and disappear when their patch window closes.
 
 `graph.split_edge` takes the clicked oriented projection index, inserts a node at
 the nearest point on the target edge, and replaces it with two connected edges.

--- a/src/mipview/control/README.md
+++ b/src/mipview/control/README.md
@@ -438,7 +438,8 @@ Graph commands target an open patch window by the session ID reported in
 three projections and stored in patch-local source voxel space. `add-node` uses
 oriented 2D projection indices and resolves depth from the current finite
 MIP/MinIP extremum; `add-voxel-node` accepts explicit patch-local `(x, y, z)`
-coordinates. Graph mode must be active for mutation commands.
+coordinates. Node/edge editing commands require Graph mode; clearing the complete
+graph remains available whenever the session contains graph elements.
 
 ```bash
 mipview-ctl graph status SESSION_ID
@@ -449,9 +450,12 @@ mipview-ctl graph add-voxel-node SESSION_ID 12 18 7
 mipview-ctl graph add-edge SESSION_ID axial 1 2
 mipview-ctl graph curve-edge SESSION_ID axial 1 2 18.5 24.0
 mipview-ctl graph straighten-edge SESSION_ID axial 1 2
+mipview-ctl graph normal-line SESSION_ID axial 1 2 show
+mipview-ctl graph extension-line SESSION_ID axial 1 2 show
 mipview-ctl graph split-edge SESSION_ID axial 1 2 18 24
 mipview-ctl graph calculate-angle SESSION_ID axial 1 2 3 4
 mipview-ctl graph clear-angle SESSION_ID
+mipview-ctl graph clear SESSION_ID
 mipview-ctl graph delete-edge SESSION_ID axial 1 2
 mipview-ctl graph delete-node SESSION_ID axial 1
 mipview-ctl graph exit SESSION_ID
@@ -460,8 +464,9 @@ mipview-ctl graph exit SESSION_ID
 The matching direct commands are `graph.status`, `graph.activate`,
 `graph.set_display`, `graph.add_node`, `graph.delete_node`, `graph.add_edge`,
 `graph.add_voxel_node`, `graph.delete_edge`, `graph.curve_edge`,
-`graph.straighten_edge`, `graph.split_edge`, `graph.calculate_angle`, and
-`graph.clear_angle`.
+`graph.straighten_edge`, `graph.set_normal_line`, `graph.set_extension_line`,
+`graph.split_edge`, `graph.calculate_angle`, `graph.clear_angle`, and
+`graph.clear`.
 
 Curve controls use floating-point oriented projection coordinates and must be
 finite and inside the projection plane. They update a shared 3D control point by

--- a/src/mipview/control/cli.py
+++ b/src/mipview/control/cli.py
@@ -246,8 +246,9 @@ def _build_parser() -> argparse.ArgumentParser:
         "graph",
         help="Inspect and edit projection graphs in open patch windows.",
         description=(
-            "Graph commands use an open patch window session ID and 2D oriented "
-            "projection coordinates, not source voxel or screen coordinates."
+            "Graph commands use an open patch window session ID. Projection nodes "
+            "resolve depth from the current MIP/MinIP; voxel nodes use patch-local "
+            "source-array coordinates."
         ),
         formatter_class=_HelpFormatter,
     )
@@ -281,6 +282,14 @@ def _build_parser() -> argparse.ArgumentParser:
     graph_add_node.add_argument("view", metavar="VIEW")
     graph_add_node.add_argument("horizontal", metavar="HORIZONTAL", type=int)
     graph_add_node.add_argument("vertical", metavar="VERTICAL", type=int)
+    graph_add_voxel_node = graph_subparsers.add_parser(
+        "add-voxel-node",
+        help="Create a node at an explicit patch-local source voxel.",
+    )
+    graph_add_voxel_node.add_argument("session_id", metavar="SESSION_ID")
+    graph_add_voxel_node.add_argument("x", metavar="X", type=int)
+    graph_add_voxel_node.add_argument("y", metavar="Y", type=int)
+    graph_add_voxel_node.add_argument("z", metavar="Z", type=int)
     graph_delete_node = graph_subparsers.add_parser(
         "delete-node", help="Delete a graph node and its connected edges."
     )
@@ -518,6 +527,17 @@ def _command_from_args(args: argparse.Namespace) -> tuple[str, dict[str, Any], A
                     "view": args.view,
                     "horizontal": args.horizontal,
                     "vertical": args.vertical,
+                },
+                None,
+            )
+        if args.graph_command == "add-voxel-node":
+            return (
+                "graph.add_voxel_node",
+                {
+                    "session_id": args.session_id,
+                    "x": args.x,
+                    "y": args.y,
+                    "z": args.z,
                 },
                 None,
             )

--- a/src/mipview/control/cli.py
+++ b/src/mipview/control/cli.py
@@ -326,6 +326,28 @@ def _build_parser() -> argparse.ArgumentParser:
     graph_straighten_edge.add_argument("view", metavar="VIEW")
     graph_straighten_edge.add_argument("start_node_id", metavar="START_NODE_ID", type=int)
     graph_straighten_edge.add_argument("end_node_id", metavar="END_NODE_ID", type=int)
+    graph_normal_line = graph_subparsers.add_parser(
+        "normal-line",
+        help="Show or hide the projected normal through a straight graph edge.",
+    )
+    graph_normal_line.add_argument("session_id", metavar="SESSION_ID")
+    graph_normal_line.add_argument("view", metavar="VIEW")
+    graph_normal_line.add_argument("start_node_id", metavar="START_NODE_ID", type=int)
+    graph_normal_line.add_argument("end_node_id", metavar="END_NODE_ID", type=int)
+    graph_normal_line.add_argument("visibility", choices=("show", "hide"))
+    graph_extension_line = graph_subparsers.add_parser(
+        "extension-line",
+        help="Show or hide the projected extension through a straight graph edge.",
+    )
+    graph_extension_line.add_argument("session_id", metavar="SESSION_ID")
+    graph_extension_line.add_argument("view", metavar="VIEW")
+    graph_extension_line.add_argument(
+        "start_node_id", metavar="START_NODE_ID", type=int
+    )
+    graph_extension_line.add_argument(
+        "end_node_id", metavar="END_NODE_ID", type=int
+    )
+    graph_extension_line.add_argument("visibility", choices=("show", "hide"))
     graph_split_edge = graph_subparsers.add_parser(
         "split-edge", help="Create a node on an edge and replace it with two edges."
     )
@@ -348,6 +370,10 @@ def _build_parser() -> argparse.ArgumentParser:
         "clear-angle", help="Clear the stored graph angle measurement."
     )
     graph_clear_angle.add_argument("session_id", metavar="SESSION_ID")
+    graph_clear = graph_subparsers.add_parser(
+        "clear", help="Clear all graph nodes, edges, curves, and measurements."
+    )
+    graph_clear.add_argument("session_id", metavar="SESSION_ID")
 
     annotation_parser = subparsers.add_parser(
         "annotation",
@@ -589,6 +615,30 @@ def _command_from_args(args: argparse.Namespace) -> tuple[str, dict[str, Any], A
                 arguments,
                 None,
             )
+        if args.graph_command == "normal-line":
+            return (
+                "graph.set_normal_line",
+                {
+                    "session_id": args.session_id,
+                    "view": args.view,
+                    "start_node_id": args.start_node_id,
+                    "end_node_id": args.end_node_id,
+                    "visible": args.visibility == "show",
+                },
+                None,
+            )
+        if args.graph_command == "extension-line":
+            return (
+                "graph.set_extension_line",
+                {
+                    "session_id": args.session_id,
+                    "view": args.view,
+                    "start_node_id": args.start_node_id,
+                    "end_node_id": args.end_node_id,
+                    "visible": args.visibility == "show",
+                },
+                None,
+            )
         if args.graph_command == "split-edge":
             return (
                 "graph.split_edge",
@@ -617,6 +667,8 @@ def _command_from_args(args: argparse.Namespace) -> tuple[str, dict[str, Any], A
             )
         if args.graph_command == "clear-angle":
             return "graph.clear_angle", {"session_id": args.session_id}, None
+        if args.graph_command == "clear":
+            return "graph.clear", {"session_id": args.session_id}, None
 
     if args.group == "annotation":
         if args.annotation_command == "create":

--- a/src/mipview/control/command_registry.py
+++ b/src/mipview/control/command_registry.py
@@ -63,9 +63,15 @@ class CommandRegistry:
         self.register("graph.delete_edge", self.controller.delete_graph_edge)
         self.register("graph.curve_edge", self.controller.curve_graph_edge)
         self.register("graph.straighten_edge", self.controller.straighten_graph_edge)
+        self.register("graph.set_normal_line", self.controller.set_graph_normal_line)
+        self.register(
+            "graph.set_extension_line",
+            self.controller.set_graph_extension_line,
+        )
         self.register("graph.split_edge", self.controller.split_graph_edge)
         self.register("graph.calculate_angle", self.controller.calculate_graph_angle)
         self.register("graph.clear_angle", self.controller.clear_graph_angle)
+        self.register("graph.clear", self.controller.clear_graph)
         self.register("annotation.create", self.controller.create_annotation)
         self.register("annotation.paint_stroke", self.controller.paint_annotation_stroke)
         self.register("annotation.erase_stroke", self.controller.erase_annotation_stroke)

--- a/src/mipview/control/command_registry.py
+++ b/src/mipview/control/command_registry.py
@@ -57,6 +57,7 @@ class CommandRegistry:
         self.register("graph.activate", self.controller.set_graph_active)
         self.register("graph.set_display", self.controller.set_graph_display)
         self.register("graph.add_node", self.controller.add_graph_node)
+        self.register("graph.add_voxel_node", self.controller.add_graph_voxel_node)
         self.register("graph.delete_node", self.controller.delete_graph_node)
         self.register("graph.add_edge", self.controller.add_graph_edge)
         self.register("graph.delete_edge", self.controller.delete_graph_edge)

--- a/src/mipview/control/controller.py
+++ b/src/mipview/control/controller.py
@@ -544,6 +544,74 @@ class MipViewController:
             },
         )
 
+    def set_graph_normal_line(
+        self,
+        session_id: str,
+        view: str,
+        start_node_id: int,
+        end_node_id: int,
+        visible: bool,
+    ) -> CommandResult:
+        patch_window = self._graph_patch_window(session_id)
+        if patch_window is None:
+            return self._graph_session_not_found(session_id)
+        orientation = _validate_orientation(view)
+        if orientation is None:
+            return CommandResult(False, "Graph view must be axial, coronal, or sagittal.")
+        try:
+            normal_visible = patch_window.set_graph_normal_line(
+                orientation,
+                int(start_node_id),
+                int(end_node_id),
+                bool(visible),
+            )
+        except (TypeError, ValueError) as exc:
+            return CommandResult(False, str(exc), {"session_id": session_id})
+        return CommandResult(
+            True,
+            "Graph edge normal line displayed."
+            if normal_visible
+            else "Graph edge normal line hidden.",
+            {
+                "session_id": session_id,
+                "normal_line": patch_window.graph_status()["normal_line"],
+            },
+        )
+
+    def set_graph_extension_line(
+        self,
+        session_id: str,
+        view: str,
+        start_node_id: int,
+        end_node_id: int,
+        visible: bool,
+    ) -> CommandResult:
+        patch_window = self._graph_patch_window(session_id)
+        if patch_window is None:
+            return self._graph_session_not_found(session_id)
+        orientation = _validate_orientation(view)
+        if orientation is None:
+            return CommandResult(False, "Graph view must be axial, coronal, or sagittal.")
+        try:
+            extension_visible = patch_window.set_graph_extension_line(
+                orientation,
+                int(start_node_id),
+                int(end_node_id),
+                bool(visible),
+            )
+        except (TypeError, ValueError) as exc:
+            return CommandResult(False, str(exc), {"session_id": session_id})
+        return CommandResult(
+            True,
+            "Graph edge extension line displayed."
+            if extension_visible
+            else "Graph edge extension line hidden.",
+            {
+                "session_id": session_id,
+                "extension_line": patch_window.graph_status()["extension_line"],
+            },
+        )
+
     def split_graph_edge(
         self,
         session_id: str,
@@ -641,6 +709,21 @@ class MipViewController:
             True,
             "Graph angle cleared.",
             patch_window.graph_status(),
+        )
+
+    def clear_graph(self, session_id: str) -> CommandResult:
+        patch_window = self._graph_patch_window(session_id)
+        if patch_window is None:
+            return self._graph_session_not_found(session_id)
+        node_count, edge_count = patch_window.clear_graph()
+        return CommandResult(
+            True,
+            "Graph nodes and edges cleared.",
+            {
+                **patch_window.graph_status(),
+                "cleared_node_count": node_count,
+                "cleared_edge_count": edge_count,
+            },
         )
 
     def _mutate_graph_edge(

--- a/src/mipview/control/controller.py
+++ b/src/mipview/control/controller.py
@@ -382,11 +382,30 @@ class MipViewController:
             {
                 "session_id": session_id,
                 "view": orientation,
-                "node": {
-                    "id": node.id,
-                    "horizontal_index": node.horizontal_index,
-                    "vertical_index": node.vertical_index,
-                },
+                "node": patch_window.graph_node_payload(node, orientation),
+            },
+        )
+
+    def add_graph_voxel_node(
+        self,
+        session_id: str,
+        x: int,
+        y: int,
+        z: int,
+    ) -> CommandResult:
+        patch_window = self._graph_patch_window(session_id)
+        if patch_window is None:
+            return self._graph_session_not_found(session_id)
+        try:
+            node = patch_window.add_graph_voxel_node(int(x), int(y), int(z))
+        except ValueError as exc:
+            return CommandResult(False, str(exc), {"session_id": session_id})
+        return CommandResult(
+            True,
+            "Graph voxel node created.",
+            {
+                "session_id": session_id,
+                "node": patch_window.graph_node_payload(node),
             },
         )
 
@@ -467,7 +486,10 @@ class MipViewController:
             )
         except (TypeError, ValueError) as exc:
             return CommandResult(False, str(exc), {"session_id": session_id})
-        control = patch_window.graph_state.layer(orientation).curve_control_points[edge]
+        projected_control = patch_window.slice_viewer.graph_projected_layer(
+            orientation
+        ).curve_control_points[edge]
+        voxel_control = patch_window.graph_state.graph.curve_control_points[edge]
         return CommandResult(
             True,
             "Graph edge curved.",
@@ -477,7 +499,13 @@ class MipViewController:
                 "edge": {
                     "start_node_id": edge.start_node_id,
                     "end_node_id": edge.end_node_id,
-                    "control_point": [float(control[0]), float(control[1])],
+                    "control_point": [
+                        float(projected_control[0]),
+                        float(projected_control[1]),
+                    ],
+                    "control_patch_voxel": [
+                        float(value) for value in voxel_control
+                    ],
                 },
             },
         )
@@ -547,11 +575,7 @@ class MipViewController:
             {
                 "session_id": session_id,
                 "view": orientation,
-                "node": {
-                    "id": node.id,
-                    "horizontal_index": node.horizontal_index,
-                    "vertical_index": node.vertical_index,
-                },
+                "node": patch_window.graph_node_payload(node, orientation),
                 "edges": [
                     {
                         "start_node_id": first_edge.start_node_id,

--- a/src/mipview/graph/README.md
+++ b/src/mipview/graph/README.md
@@ -38,12 +38,30 @@ node is placed at the nearest projection index on the edge, the original edge is
 replaced by two connected edges, and quadratic subdivision preserves curved-edge
 geometry.
 
+Right-clicking a straight edge also offers **Display the normal line**. It draws
+a one-pixel fluorescent-yellow dashed line through the projected edge midpoint,
+normal to the edge and extended to the projection boundaries. The menu changes
+to **Hide the normal line** while that view-specific construction line is shown.
+Only one normal line is retained at a time, and curving, splitting, deleting, or
+clearing its edge removes it.
+
+The same straight-edge menu offers **Display the extension line**. It draws a
+one-pixel fluorescent-blue dashed supporting line through both projected edge
+endpoints and extends it to the projection boundaries. The original solid edge
+is drawn above the construction line, leaving the dashed extensions visible
+beyond its endpoints. The menu changes to **Hide the extension line** while it
+is shown. One view-specific extension line is retained at a time, independently
+of the normal line, and it follows the same automatic removal rules.
+
 **Calculate Angle** selects four shared nodes in source/target order for two
 directed vectors. All four selections must use one orientation because the result
 is the projected view angle, not a 3D angle. It uses physical in-plane voxel
 spacing and is therefore not distorted by anisotropic voxels. Yellow arrows and
 the result remain until **Clear Angle**; **Cancel** discards only an incomplete
 replacement measurement.
+
+**Clear All Nodes & Edges** clears the shared graph in every orientation,
+including curve controls, pending interactions, and stored angle measurements.
 
 Rendering uses direct `QPainter` primitives and `QPainterPath`, so graph memory
 grows with node and edge count rather than patch-volume size.

--- a/src/mipview/graph/README.md
+++ b/src/mipview/graph/README.md
@@ -1,19 +1,35 @@
 # Projection Graph Mode
 
 Patch windows provide a sparse, session-only graph editor for MIP and MinIP
-views. Graph coordinates are 2D oriented projection-array indices, not screen
-pixels and not 3D voxel coordinates.
+views. The authoritative graph uses patch-local source-array voxel coordinates;
+the axial, coronal, and sagittal overlays are projections of that shared graph.
 
-- Axial, coronal, and sagittal projections each own an independent graph layer.
-- Each orientation layer is shared when switching between MIP and MinIP.
+- Nodes and edges created in one orientation appear in all enabled orientations.
+- Completed graph geometry is retained when switching between MIP and MinIP.
 - Graphs are rendered and editable only while their orientation is projected.
 - Graph mode exits automatically after the last projection is disabled.
-- Closing the patch window permanently discards its graph layers.
+- Closing the patch window permanently discards its graph.
+
+Creating a node from a 2D projection resolves the missing coordinate from the
+current image ray: MIP uses the finite maximum and MinIP uses the finite minimum.
+The selected projection mask restricts contributing voxels. Equal extrema choose
+the depth nearest the current cursor and then the lower index. Empty or non-finite
+rays fail explicitly. Once resolved, a node does not move when projection mode or
+mask changes. This intensity-derived depth is a reviewable aid and is not proof
+that the selected voxel represents the intended anatomy.
+
+The command interface retains `graph.add_node` for oriented projection indices.
+`graph.add_voxel_node` (CLI: `graph add-voxel-node`) creates an unambiguous node
+from patch-local `(x, y, z)` source-array coordinates. Command results and
+`graph.status` include patch voxels, full-image voxels when patch bounds exist,
+and derived coordinates for all three orientations.
 
 Nodes are stored in dictionaries and edges as normalized node-ID pairs. Optional
 quadratic Bezier control points are stored separately from edge identity. Use
 **Curve Edge** from the Graph panel or an edge context menu, select an edge, and
-drag its control handle. **Straighten Edge** removes only the control point.
+drag its projected control handle. Control points are 3D: dragging changes the
+two visible coordinates and preserves depth, allowing refinement from another
+orientation. **Straighten Edge** removes only the shared control point.
 Once the blue control handle is visible, a left-click anywhere outside that
 handle exits Curve Edge mode and hides the handle.
 
@@ -22,20 +38,21 @@ node is placed at the nearest projection index on the edge, the original edge is
 replaced by two connected edges, and quadratic subdivision preserves curved-edge
 geometry.
 
-**Calculate Angle** selects four existing nodes in source/target order for two
-directed vectors. Both vectors must use one orientation. The displayed unsigned
-angle uses the physical in-plane voxel spacing and is therefore not distorted by
-anisotropic voxels. Yellow arrows and the result remain until **Clear Angle**;
-**Cancel** discards only an incomplete replacement measurement.
+**Calculate Angle** selects four shared nodes in source/target order for two
+directed vectors. All four selections must use one orientation because the result
+is the projected view angle, not a 3D angle. It uses physical in-plane voxel
+spacing and is therefore not distorted by anisotropic voxels. Yellow arrows and
+the result remain until **Clear Angle**; **Cancel** discards only an incomplete
+replacement measurement.
 
 Rendering uses direct `QPainter` primitives and `QPainterPath`, so graph memory
 grows with node and edge count rather than patch-volume size.
 
 Graph mode preserves right-drag zoom. A stationary right-click opens the graph
-context menu; edge completion uses a left-click on a node in the same orientation.
-Pressing Escape, exiting Graph mode, changing MIP/MinIP mode, or disabling the
-pending edge's projection cancels edge creation.
+context menu. Edge creation may start in one orientation and finish on a shared
+node in another. Pressing Escape, exiting Graph mode, changing MIP/MinIP mode, or
+disabling the pending edge's projection cancels edge creation.
 
 Changing MIP/MinIP mode also cancels active curve/angle interaction while keeping
-completed curves and measurements. A projection-shape change clears the affected
-graph layers and any measurements that reference them.
+completed curves and measurements. An incompatible patch-volume geometry change
+clears the shared graph and its measurements.

--- a/src/mipview/graph/__init__.py
+++ b/src/mipview/graph/__init__.py
@@ -10,16 +10,24 @@ from mipview.graph.measurement import (
     DirectedGraphVector,
     calculate_unsigned_angle_degrees,
 )
-from mipview.graph.model import GraphEdge, GraphNode, ProjectionGraphLayer
+from mipview.graph.model import (
+    GraphEdge,
+    GraphNode,
+    ProjectedGraphNode,
+    ProjectionGraphLayer,
+    VoxelGraph,
+)
 from mipview.graph.state import ORIENTATIONS, ProjectionGraphState
 
 __all__ = [
     "GraphEdge",
     "GraphNode",
+    "ProjectedGraphNode",
     "DirectedGraphVector",
     "ORIENTATIONS",
     "ProjectionGraphLayer",
     "ProjectionGraphState",
+    "VoxelGraph",
     "calculate_unsigned_angle_degrees",
     "nearest_quadratic_bezier_parameter",
     "point_to_quadratic_bezier_distance",

--- a/src/mipview/graph/model.py
+++ b/src/mipview/graph/model.py
@@ -3,20 +3,34 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import math
 
-from mipview.graph.curve import (
-    nearest_quadratic_bezier_parameter,
-    split_quadratic_bezier,
-)
 from mipview.viewer.slice_geometry import Orientation
+
+
+VoxelPoint = tuple[float, float, float]
 
 
 @dataclass(frozen=True)
 class GraphNode:
-    id: int
-    horizontal_index: int
-    vertical_index: int
+    """A graph node in patch-local source voxel coordinates."""
 
-    def position(self) -> tuple[int, int]:
+    id: int
+    x: int
+    y: int
+    z: int
+
+    def position(self) -> tuple[int, int, int]:
+        return (self.x, self.y, self.z)
+
+
+@dataclass(frozen=True)
+class ProjectedGraphNode:
+    """A read-only 2D projection of a shared graph node."""
+
+    id: int
+    horizontal_index: float
+    vertical_index: float
+
+    def position(self) -> tuple[float, float]:
         return (self.horizontal_index, self.vertical_index)
 
 
@@ -34,38 +48,45 @@ class GraphEdge:
         return cls(min(first, second), max(first, second))
 
 
-@dataclass
+@dataclass(frozen=True)
 class ProjectionGraphLayer:
+    """Read-only rendering geometry derived from one shared voxel graph."""
+
     orientation: Orientation
-    plane_shape: tuple[int, int] | None = None
+    plane_shape: tuple[int, int]
+    nodes: dict[int, ProjectedGraphNode]
+    edges: frozenset[GraphEdge]
+    curve_control_points: dict[GraphEdge, tuple[float, float]]
+    node_hit_priorities: dict[int, int] = field(default_factory=dict)
+
+
+@dataclass
+class VoxelGraph:
+    """Session graph whose authoritative coordinates are patch-local voxels."""
+
+    volume_shape: tuple[int, int, int] | None = None
     nodes: dict[int, GraphNode] = field(default_factory=dict)
     edges: set[GraphEdge] = field(default_factory=set)
-    curve_control_points: dict[GraphEdge, tuple[float, float]] = field(
-        default_factory=dict
-    )
+    curve_control_points: dict[GraphEdge, VoxelPoint] = field(default_factory=dict)
     _next_node_id: int = 1
 
-    def set_plane_shape(self, plane_shape: tuple[int, int]) -> bool:
-        width, height = (int(plane_shape[0]), int(plane_shape[1]))
-        if width <= 0 or height <= 0:
-            raise ValueError(f"Graph projection shape must be positive, got {(width, height)}.")
-        normalized_shape = (width, height)
-        if self.plane_shape == normalized_shape:
+    def set_volume_shape(self, volume_shape: tuple[int, int, int]) -> bool:
+        normalized = tuple(int(value) for value in volume_shape)
+        if len(normalized) != 3 or any(value <= 0 for value in normalized):
+            raise ValueError(f"Graph volume shape must be positive 3D, got {normalized}.")
+        if self.volume_shape == normalized:
             return False
         cleared = bool(self.nodes or self.edges)
         self.clear()
-        self.plane_shape = normalized_shape
+        self.volume_shape = normalized
         return cleared
 
-    def add_node(self, horizontal_index: int, vertical_index: int) -> GraphNode:
-        horizontal = int(horizontal_index)
-        vertical = int(vertical_index)
-        self._validate_position(horizontal, vertical)
-        if any(node.position() == (horizontal, vertical) for node in self.nodes.values()):
-            raise ValueError(
-                f"A graph node already exists at projection coordinate {(horizontal, vertical)}."
-            )
-        node = GraphNode(self._next_node_id, horizontal, vertical)
+    def add_node(self, x: int, y: int, z: int) -> GraphNode:
+        position = (int(x), int(y), int(z))
+        self._validate_node_position(position)
+        if any(node.position() == position for node in self.nodes.values()):
+            raise ValueError(f"A graph node already exists at patch voxel {position}.")
+        node = GraphNode(self._next_node_id, *position)
         self.nodes[node.id] = node
         self._next_node_id += 1
         return node
@@ -81,11 +102,7 @@ class ProjectionGraphLayer:
             for edge in self.edges
             if normalized_id in (edge.start_node_id, edge.end_node_id)
         }
-        self.edges = {
-            edge
-            for edge in self.edges
-            if normalized_id not in (edge.start_node_id, edge.end_node_id)
-        }
+        self.edges.difference_update(removed_edges)
         for edge in removed_edges:
             self.curve_control_points.pop(edge, None)
         return node
@@ -114,16 +131,16 @@ class ProjectionGraphLayer:
         self,
         first_node_id: int,
         second_node_id: int,
-        control_point: tuple[float, float],
+        control_point: VoxelPoint,
     ) -> GraphEdge:
         edge = GraphEdge.between(first_node_id, second_node_id)
         if edge not in self.edges:
             raise ValueError(
                 f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
             )
-        horizontal, vertical = (float(control_point[0]), float(control_point[1]))
-        self._validate_control_point(horizontal, vertical)
-        self.curve_control_points[edge] = (horizontal, vertical)
+        normalized = tuple(float(value) for value in control_point)
+        self._validate_control_point(normalized)
+        self.curve_control_points[edge] = normalized
         return edge
 
     def straighten_edge(self, first_node_id: int, second_node_id: int) -> GraphEdge:
@@ -135,7 +152,12 @@ class ProjectionGraphLayer:
         self.curve_control_points.pop(edge, None)
         return edge
 
-    def ensure_curve_control_point(self, edge: GraphEdge) -> tuple[float, float]:
+    def ensure_curve_control_point(self, edge: GraphEdge) -> VoxelPoint:
+        control_point = self.curve_control_point_or_midpoint(edge)
+        self.curve_control_points[edge] = control_point
+        return control_point
+
+    def curve_control_point_or_midpoint(self, edge: GraphEdge) -> VoxelPoint:
         if edge not in self.edges:
             raise ValueError(
                 f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
@@ -143,61 +165,56 @@ class ProjectionGraphLayer:
         existing = self.curve_control_points.get(edge)
         if existing is not None:
             return existing
-        start = self.nodes[edge.start_node_id]
-        end = self.nodes[edge.end_node_id]
-        midpoint = (
-            (start.horizontal_index + end.horizontal_index) / 2.0,
-            (start.vertical_index + end.vertical_index) / 2.0,
-        )
-        self.curve_control_points[edge] = midpoint
-        return midpoint
+        start = self.nodes[edge.start_node_id].position()
+        end = self.nodes[edge.end_node_id].position()
+        midpoint = tuple((start[index] + end[index]) / 2.0 for index in range(3))
+        return midpoint  # type: ignore[return-value]
 
-    def split_edge(
+    def split_edge_at_parameter(
         self,
         first_node_id: int,
         second_node_id: int,
-        near_position: tuple[int, int] | tuple[float, float],
+        parameter: float,
     ) -> tuple[GraphNode, GraphEdge, GraphEdge]:
-        """Insert a node at the nearest edge point and replace the edge in two."""
+        """Split an edge transactionally at a parameter derived from a projection."""
         edge = GraphEdge.between(first_node_id, second_node_id)
         if edge not in self.edges:
             raise ValueError(
                 f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
             )
-        start_node = self.nodes[edge.start_node_id]
-        end_node = self.nodes[edge.end_node_id]
-        start = (float(start_node.horizontal_index), float(start_node.vertical_index))
-        end = (float(end_node.horizontal_index), float(end_node.vertical_index))
-        point = (float(near_position[0]), float(near_position[1]))
+        t = min(max(float(parameter), 0.0), 1.0)
+        start = tuple(float(v) for v in self.nodes[edge.start_node_id].position())
+        end = tuple(float(v) for v in self.nodes[edge.end_node_id].position())
         control = self.curve_control_points.get(edge)
         if control is None:
-            parameter = _nearest_segment_parameter(point, start, end)
-            split_point = (
-                start[0] + ((end[0] - start[0]) * parameter),
-                start[1] + ((end[1] - start[1]) * parameter),
-            )
+            split_point = _interpolate_3d(start, end, t)
             left_control = None
             right_control = None
         else:
-            parameter = nearest_quadratic_bezier_parameter(
-                point,
-                start,
-                control,
-                end,
-            )
-            split_point, left_control, right_control = split_quadratic_bezier(
-                start,
-                control,
-                end,
-                parameter,
-            )
+            left_control = _interpolate_3d(start, control, t)
+            right_control = _interpolate_3d(control, end, t)
+            split_point = _interpolate_3d(left_control, right_control, t)
 
-        horizontal = int(round(split_point[0]))
-        vertical = int(round(split_point[1]))
-        new_node = self.add_node(horizontal, vertical)
-        self.delete_edge(edge.start_node_id, edge.end_node_id)
-        first_edge = self.add_edge(edge.start_node_id, new_node.id)
-        second_edge = self.add_edge(new_node.id, edge.end_node_id)
+        rounded = tuple(int(round(value)) for value in split_point)
+        self._validate_node_position(rounded)
+        endpoint_positions = {
+            self.nodes[edge.start_node_id].position(),
+            self.nodes[edge.end_node_id].position(),
+        }
+        if rounded in endpoint_positions:
+            raise ValueError("Graph edge split is too close to an endpoint voxel.")
+        if any(node.position() == rounded for node in self.nodes.values()):
+            raise ValueError(f"A graph node already exists at patch voxel {rounded}.")
+
+        new_node = GraphNode(self._next_node_id, *rounded)
+        first_edge = GraphEdge.between(edge.start_node_id, new_node.id)
+        second_edge = GraphEdge.between(new_node.id, edge.end_node_id)
+
+        self.edges.remove(edge)
+        self.curve_control_points.pop(edge, None)
+        self.nodes[new_node.id] = new_node
+        self._next_node_id += 1
+        self.edges.update((first_edge, second_edge))
         if left_control is not None and right_control is not None:
             self.curve_control_points[first_edge] = left_control
             self.curve_control_points[second_edge] = right_control
@@ -209,14 +226,15 @@ class ProjectionGraphLayer:
         self.curve_control_points.clear()
         self._next_node_id = 1
 
-    def _validate_position(self, horizontal_index: int, vertical_index: int) -> None:
-        if self.plane_shape is None:
-            raise ValueError("Graph projection shape is not available.")
-        width, height = self.plane_shape
-        if not (0 <= horizontal_index < width and 0 <= vertical_index < height):
+    def _validate_node_position(self, position: tuple[int, int, int]) -> None:
+        if self.volume_shape is None:
+            raise ValueError("Graph volume shape is not available.")
+        if any(
+            coordinate < 0 or coordinate >= self.volume_shape[axis]
+            for axis, coordinate in enumerate(position)
+        ):
             raise ValueError(
-                "Graph node projection coordinate "
-                f"{(horizontal_index, vertical_index)} is outside shape {self.plane_shape}."
+                f"Graph node patch voxel {position} is outside shape {self.volume_shape}."
             )
 
     def _validate_edge_endpoints(self, edge: GraphEdge) -> None:
@@ -228,31 +246,22 @@ class ProjectionGraphLayer:
         if missing:
             raise ValueError(f"Graph edge references missing node(s): {missing}.")
 
-    def _validate_control_point(self, horizontal: float, vertical: float) -> None:
-        if self.plane_shape is None:
-            raise ValueError("Graph projection shape is not available.")
-        if not math.isfinite(horizontal) or not math.isfinite(vertical):
+    def _validate_control_point(self, point: VoxelPoint) -> None:
+        if self.volume_shape is None:
+            raise ValueError("Graph volume shape is not available.")
+        if not all(math.isfinite(value) for value in point):
             raise ValueError("Curve control point coordinates must be finite.")
-        width, height = self.plane_shape
-        if not (0.0 <= horizontal <= width - 1 and 0.0 <= vertical <= height - 1):
+        if any(
+            coordinate < 0.0 or coordinate > self.volume_shape[axis] - 1
+            for axis, coordinate in enumerate(point)
+        ):
             raise ValueError(
-                "Curve control point "
-                f"{(horizontal, vertical)} is outside shape {self.plane_shape}."
+                f"Curve control point {point} is outside shape {self.volume_shape}."
             )
 
 
-def _nearest_segment_parameter(
-    point: tuple[float, float],
-    start: tuple[float, float],
-    end: tuple[float, float],
-) -> float:
-    delta_x = end[0] - start[0]
-    delta_y = end[1] - start[1]
-    squared_length = (delta_x * delta_x) + (delta_y * delta_y)
-    if squared_length <= 0.0:
-        return 0.0
-    parameter = (
-        ((point[0] - start[0]) * delta_x)
-        + ((point[1] - start[1]) * delta_y)
-    ) / squared_length
-    return min(max(parameter, 0.0), 1.0)
+def _interpolate_3d(start: VoxelPoint, end: VoxelPoint, t: float) -> VoxelPoint:
+    return tuple(
+        start[index] + ((end[index] - start[index]) * t)
+        for index in range(3)
+    )  # type: ignore[return-value]

--- a/src/mipview/graph/spatial.py
+++ b/src/mipview/graph/spatial.py
@@ -204,6 +204,86 @@ def nearest_projected_edge_parameter(
     return _nearest_segment_parameter(point, start, end)
 
 
+def normal_line_plane_endpoints(
+    layer: ProjectionGraphLayer,
+    edge: GraphEdge,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Clip the infinite projected normal through an edge midpoint to its plane."""
+    if edge not in layer.edges:
+        raise ValueError(
+            f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
+        )
+    if edge in layer.curve_control_points:
+        raise ValueError("A normal line is available only for a straight edge.")
+    start = layer.nodes[edge.start_node_id].position()
+    end = layer.nodes[edge.end_node_id].position()
+    delta_x = end[0] - start[0]
+    delta_y = end[1] - start[1]
+    if float(np.hypot(delta_x, delta_y)) <= 0.0:
+        raise ValueError(
+            "A normal line cannot be displayed for a zero-length projected edge."
+        )
+
+    midpoint = ((start[0] + end[0]) / 2.0, (start[1] + end[1]) / 2.0)
+    return _clip_infinite_line_to_plane(
+        midpoint,
+        (-delta_y, delta_x),
+        layer.plane_shape,
+    )
+
+
+def extension_line_plane_endpoints(
+    layer: ProjectionGraphLayer,
+    edge: GraphEdge,
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    """Clip the infinite supporting line of a projected edge to its plane."""
+    if edge not in layer.edges:
+        raise ValueError(
+            f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
+        )
+    if edge in layer.curve_control_points:
+        raise ValueError("An extension line is available only for a straight edge.")
+    start = layer.nodes[edge.start_node_id].position()
+    end = layer.nodes[edge.end_node_id].position()
+    direction = (end[0] - start[0], end[1] - start[1])
+    if float(np.hypot(*direction)) <= 0.0:
+        raise ValueError(
+            "An extension line cannot be displayed for a zero-length projected edge."
+        )
+    return _clip_infinite_line_to_plane(start, direction, layer.plane_shape)
+
+
+def _clip_infinite_line_to_plane(
+    point: tuple[float, float],
+    direction: tuple[float, float],
+    plane_shape: tuple[int, int],
+) -> tuple[tuple[float, float], tuple[float, float]]:
+    width, height = plane_shape
+    max_x = float(width - 1)
+    max_y = float(height - 1)
+    intersections: list[tuple[float, tuple[float, float]]] = []
+
+    if direction[0] != 0.0:
+        for x in (0.0, max_x):
+            parameter = (x - point[0]) / direction[0]
+            y = point[1] + (parameter * direction[1])
+            if -1e-9 <= y <= max_y + 1e-9:
+                intersections.append((parameter, (x, min(max(y, 0.0), max_y))))
+    if direction[1] != 0.0:
+        for y in (0.0, max_y):
+            parameter = (y - point[1]) / direction[1]
+            x = point[0] + (parameter * direction[0])
+            if -1e-9 <= x <= max_x + 1e-9:
+                intersections.append((parameter, (min(max(x, 0.0), max_x), y)))
+
+    if len(intersections) < 2:
+        raise ValueError(
+            "The projected construction line does not cross the graph plane."
+        )
+    intersections.sort(key=lambda item: item[0])
+    return intersections[0][1], intersections[-1][1]
+
+
 def _nearest_segment_parameter(
     point: tuple[float, float],
     start: tuple[float, float],

--- a/src/mipview/graph/spatial.py
+++ b/src/mipview/graph/spatial.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from mipview.graph.curve import nearest_quadratic_bezier_parameter
+from mipview.graph.model import (
+    GraphEdge,
+    ProjectedGraphNode,
+    ProjectionGraphLayer,
+    VoxelGraph,
+    VoxelPoint,
+)
+from mipview.viewer.oriented_volume import OrientedVolume
+from mipview.viewer.slice_geometry import (
+    Orientation,
+    plane_definition_for_orientation,
+    plane_shape_for_orientation,
+)
+
+
+def build_projected_graph_layer(
+    graph: VoxelGraph,
+    oriented_volume: OrientedVolume,
+    orientation: Orientation,
+) -> ProjectionGraphLayer:
+    nodes = {
+        node.id: ProjectedGraphNode(
+            node.id,
+            *project_source_point(node.position(), oriented_volume, orientation),
+        )
+        for node in graph.nodes.values()
+    }
+    controls = {
+        edge: project_source_point(point, oriented_volume, orientation)
+        for edge, point in graph.curve_control_points.items()
+    }
+    return ProjectionGraphLayer(
+        orientation=orientation,
+        plane_shape=plane_shape_for_orientation(
+            oriented_volume.display_shape,
+            orientation,
+        ),
+        nodes=nodes,
+        edges=frozenset(graph.edges),
+        curve_control_points=controls,
+    )
+
+
+def project_source_point(
+    source_point: tuple[int, int, int] | VoxelPoint,
+    oriented_volume: OrientedVolume,
+    orientation: Orientation,
+) -> tuple[float, float]:
+    display_point = _transform_point(
+        tuple(float(value) for value in source_point),
+        oriented_volume.source_to_display_affine,
+    )
+    definition = plane_definition_for_orientation(orientation)
+    horizontal = display_point[definition.horizontal_axis]
+    vertical = display_point[definition.vertical_axis]
+    if definition.horizontal_flipped:
+        horizontal = (
+            oriented_volume.display_shape[definition.horizontal_axis] - 1 - horizontal
+        )
+    if definition.vertical_flipped:
+        vertical = oriented_volume.display_shape[definition.vertical_axis] - 1 - vertical
+    return (float(horizontal), float(vertical))
+
+
+def resolve_projection_voxel(
+    oriented_volume: OrientedVolume,
+    orientation: Orientation,
+    mode: str,
+    horizontal_index: int,
+    vertical_index: int,
+    *,
+    mask_display_data: np.ndarray | None = None,
+    preferred_display_voxel: tuple[int, int, int] | None = None,
+) -> tuple[int, int, int]:
+    """Resolve a displayed projection index to its extremum source voxel."""
+    horizontal = int(horizontal_index)
+    vertical = int(vertical_index)
+    plane_shape = plane_shape_for_orientation(
+        oriented_volume.display_shape,
+        orientation,
+    )
+    if not (0 <= horizontal < plane_shape[0] and 0 <= vertical < plane_shape[1]):
+        raise ValueError(
+            f"Graph projection coordinate {(horizontal, vertical)} is outside shape "
+            f"{plane_shape}."
+        )
+
+    definition = plane_definition_for_orientation(orientation)
+    display_voxel = [0, 0, 0]
+    display_voxel[definition.horizontal_axis] = (
+        oriented_volume.display_shape[definition.horizontal_axis] - 1 - horizontal
+        if definition.horizontal_flipped
+        else horizontal
+    )
+    display_voxel[definition.vertical_axis] = (
+        oriented_volume.display_shape[definition.vertical_axis] - 1 - vertical
+        if definition.vertical_flipped
+        else vertical
+    )
+
+    ray_selector: list[int | slice] = list(display_voxel)
+    ray_selector[definition.fixed_axis] = slice(None)
+    ray_values = np.asarray(
+        oriented_volume.display_data[tuple(ray_selector)],
+        dtype=np.float64,
+    )
+    valid = np.isfinite(ray_values)
+    if mask_display_data is not None:
+        mask = np.asarray(mask_display_data)
+        if mask.shape != oriented_volume.display_shape:
+            raise ValueError("Projection mask shape must match the projected volume shape.")
+        valid &= np.asarray(mask[tuple(ray_selector)]) != 0
+    if not np.any(valid):
+        raise ValueError(
+            "The selected projection ray contains no finite contributing voxels."
+        )
+
+    normalized_mode = mode.strip().upper()
+    if normalized_mode not in {"MIP", "MINIP"}:
+        raise ValueError("Projection mode must be MIP or MinIP.")
+    valid_values = ray_values[valid]
+    extremum = (
+        float(np.max(valid_values))
+        if normalized_mode == "MIP"
+        else float(np.min(valid_values))
+    )
+    candidates = np.flatnonzero(valid & (ray_values == extremum))
+    preferred_depth = (
+        int(preferred_display_voxel[definition.fixed_axis])
+        if preferred_display_voxel is not None
+        else 0
+    )
+    fixed_index = min(
+        (int(index) for index in candidates),
+        key=lambda index: (abs(index - preferred_depth), index),
+    )
+    display_voxel[definition.fixed_axis] = fixed_index
+    return oriented_volume.display_to_source(tuple(display_voxel))
+
+
+def update_control_point_from_projection(
+    source_control_point: VoxelPoint,
+    oriented_volume: OrientedVolume,
+    orientation: Orientation,
+    horizontal: float,
+    vertical: float,
+) -> VoxelPoint:
+    """Update visible control coordinates while retaining projection depth."""
+    if not math.isfinite(horizontal) or not math.isfinite(vertical):
+        raise ValueError("Curve control point coordinates must be finite.")
+    plane_shape = plane_shape_for_orientation(oriented_volume.display_shape, orientation)
+    if not (0.0 <= horizontal <= plane_shape[0] - 1) or not (
+        0.0 <= vertical <= plane_shape[1] - 1
+    ):
+        raise ValueError(
+            f"Curve control point {(horizontal, vertical)} is outside shape {plane_shape}."
+        )
+
+    display_point = list(
+        _transform_point(
+            source_control_point,
+            oriented_volume.source_to_display_affine,
+        )
+    )
+    definition = plane_definition_for_orientation(orientation)
+    display_point[definition.horizontal_axis] = (
+        oriented_volume.display_shape[definition.horizontal_axis] - 1 - horizontal
+        if definition.horizontal_flipped
+        else horizontal
+    )
+    display_point[definition.vertical_axis] = (
+        oriented_volume.display_shape[definition.vertical_axis] - 1 - vertical
+        if definition.vertical_flipped
+        else vertical
+    )
+    return _transform_point(
+        tuple(display_point),
+        oriented_volume.display_to_source_affine,
+    )
+
+
+def nearest_projected_edge_parameter(
+    layer: ProjectionGraphLayer,
+    edge: GraphEdge,
+    near_position: tuple[int, int] | tuple[float, float],
+) -> float:
+    if edge not in layer.edges:
+        raise ValueError(
+            f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
+        )
+    start = layer.nodes[edge.start_node_id].position()
+    end = layer.nodes[edge.end_node_id].position()
+    point = (float(near_position[0]), float(near_position[1]))
+    control = layer.curve_control_points.get(edge)
+    if control is not None:
+        return nearest_quadratic_bezier_parameter(point, start, control, end)
+    return _nearest_segment_parameter(point, start, end)
+
+
+def _nearest_segment_parameter(
+    point: tuple[float, float],
+    start: tuple[float, float],
+    end: tuple[float, float],
+) -> float:
+    delta_x = end[0] - start[0]
+    delta_y = end[1] - start[1]
+    squared_length = (delta_x * delta_x) + (delta_y * delta_y)
+    if squared_length <= 0.0:
+        return 0.0
+    parameter = (
+        ((point[0] - start[0]) * delta_x)
+        + ((point[1] - start[1]) * delta_y)
+    ) / squared_length
+    return min(max(parameter, 0.0), 1.0)
+
+
+def _transform_point(point: VoxelPoint, affine: np.ndarray) -> VoxelPoint:
+    homogeneous = np.array([point[0], point[1], point[2], 1.0], dtype=np.float64)
+    mapped = np.asarray(affine, dtype=np.float64) @ homogeneous
+    return (float(mapped[0]), float(mapped[1]), float(mapped[2]))

--- a/src/mipview/graph/state.py
+++ b/src/mipview/graph/state.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, Mapping
+
+import numpy as np
 
 from mipview.graph.measurement import (
     DirectedGraphVector,
     calculate_unsigned_angle_degrees,
 )
-from mipview.graph.model import GraphEdge, ProjectionGraphLayer
+from mipview.graph.model import GraphEdge, ProjectionGraphLayer, VoxelGraph
+from mipview.graph.spatial import build_projected_graph_layer
+from mipview.viewer.oriented_volume import OrientedVolume
 from mipview.viewer.slice_geometry import Orientation
 
 
@@ -17,12 +21,7 @@ GraphTool = Literal["curve_edge", "calculate_angle"]
 
 @dataclass
 class ProjectionGraphState:
-    layers: dict[Orientation, ProjectionGraphLayer] = field(
-        default_factory=lambda: {
-            orientation: ProjectionGraphLayer(orientation)
-            for orientation in ORIENTATIONS
-        }
-    )
+    graph: VoxelGraph = field(default_factory=VoxelGraph)
     editing_enabled: bool = False
     visible: bool = True
     opacity: float = 1.0
@@ -40,11 +39,45 @@ class ProjectionGraphState:
     angle_vector_1: DirectedGraphVector | None = None
     angle_vector_2: DirectedGraphVector | None = None
     calculated_angle_degrees: float | None = None
+    _orientation_signature: tuple[float, ...] | None = field(
+        default=None,
+        repr=False,
+    )
 
-    def layer(self, orientation: Orientation) -> ProjectionGraphLayer:
-        if orientation not in self.layers:
-            raise ValueError(f"Unsupported graph orientation: {orientation}.")
-        return self.layers[orientation]
+    def projected_layer(
+        self,
+        orientation: Orientation,
+        oriented_volume: OrientedVolume,
+    ) -> ProjectionGraphLayer:
+        return build_projected_graph_layer(self.graph, oriented_volume, orientation)
+
+    def set_volume_shape(self, volume_shape: tuple[int, int, int]) -> bool:
+        cleared = self.graph.set_volume_shape(volume_shape)
+        if cleared:
+            self._clear_after_geometry_change()
+        return cleared
+
+    def set_volume_geometry(
+        self,
+        volume_shape: tuple[int, int, int],
+        source_to_display_affine: np.ndarray,
+    ) -> bool:
+        signature = tuple(
+            float(value)
+            for value in np.asarray(source_to_display_affine, dtype=np.float64).ravel()
+        )
+        orientation_changed = (
+            self._orientation_signature is not None
+            and signature != self._orientation_signature
+        )
+        cleared = self.graph.set_volume_shape(volume_shape)
+        if orientation_changed and not cleared:
+            cleared = bool(self.graph.nodes or self.graph.edges)
+            self.graph.clear()
+        self._orientation_signature = signature
+        if cleared:
+            self._clear_after_geometry_change()
+        return cleared
 
     def set_opacity(self, opacity: float) -> None:
         self.opacity = min(max(float(opacity), 0.0), 1.0)
@@ -56,9 +89,8 @@ class ProjectionGraphState:
         self.edge_thickness = min(max(int(edge_thickness), 1), 10)
 
     def begin_edge(self, orientation: Orientation, node_id: int) -> None:
-        layer = self.layer(orientation)
-        if int(node_id) not in layer.nodes:
-            raise ValueError(f"Graph node {node_id} does not exist in {orientation}.")
+        if int(node_id) not in self.graph.nodes:
+            raise ValueError(f"Graph node {node_id} does not exist.")
         self.cancel_active_tool()
         self.pending_edge_orientation = orientation
         self.pending_edge_node_id = int(node_id)
@@ -80,9 +112,8 @@ class ProjectionGraphState:
         first_node_id: int,
         second_node_id: int,
     ) -> GraphEdge:
-        layer = self.layer(orientation)
         edge = GraphEdge.between(first_node_id, second_node_id)
-        layer.ensure_curve_control_point(edge)
+        self.graph.ensure_curve_control_point(edge)
         self.active_tool = "curve_edge"
         self.selected_edge_orientation = orientation
         self.selected_edge = edge
@@ -102,14 +133,14 @@ class ProjectionGraphState:
         self,
         orientation: Orientation,
         node_id: int,
+        node_positions: Mapping[int, tuple[float, float]],
         in_plane_spacing: tuple[float, float],
     ) -> float | None:
         if self.active_tool != "calculate_angle":
             raise ValueError("Calculate Angle tool is not active.")
-        layer = self.layer(orientation)
         normalized_id = int(node_id)
-        if normalized_id not in layer.nodes:
-            raise ValueError(f"Graph node {normalized_id} does not exist in {orientation}.")
+        if normalized_id not in self.graph.nodes:
+            raise ValueError(f"Graph node {normalized_id} does not exist.")
         if self.angle_draft_nodes and orientation != self.angle_draft_nodes[0][0]:
             raise ValueError("Both vectors must use the same projection orientation.")
         if self.angle_selection_step in (1, 3):
@@ -133,11 +164,10 @@ class ProjectionGraphState:
             self.angle_draft_nodes[2][1],
             self.angle_draft_nodes[3][1],
         )
-        positions = {node.id: node.position() for node in layer.nodes.values()}
         angle = calculate_unsigned_angle_degrees(
             first,
             second,
-            positions,
+            node_positions,
             in_plane_spacing,
         )
         self.angle_vector_1 = first
@@ -154,10 +184,9 @@ class ProjectionGraphState:
         vector_1_target: int,
         vector_2_source: int,
         vector_2_target: int,
+        node_positions: Mapping[int, tuple[float, float]],
         in_plane_spacing: tuple[float, float],
     ) -> float:
-        """Validate and replace the committed measurement atomically."""
-        layer = self.layer(orientation)
         first = DirectedGraphVector(
             orientation,
             int(vector_1_source),
@@ -168,11 +197,10 @@ class ProjectionGraphState:
             int(vector_2_source),
             int(vector_2_target),
         )
-        positions = {node.id: node.position() for node in layer.nodes.values()}
         angle = calculate_unsigned_angle_degrees(
             first,
             second,
-            positions,
+            node_positions,
             in_plane_spacing,
         )
         self.angle_vector_1 = first
@@ -215,53 +243,30 @@ class ProjectionGraphState:
         if self.active_tool == "calculate_angle":
             self.active_tool = None
 
-    def invalidate_node(self, orientation: Orientation, node_id: int) -> None:
+    def invalidate_node(self, node_id: int) -> None:
         normalized_id = int(node_id)
-        if (
-            self.selected_edge_orientation == orientation
-            and self.selected_edge is not None
-            and normalized_id
-            in (self.selected_edge.start_node_id, self.selected_edge.end_node_id)
+        if self.selected_edge is not None and normalized_id in (
+            self.selected_edge.start_node_id,
+            self.selected_edge.end_node_id,
         ):
             self.selected_edge_orientation = None
             self.selected_edge = None
             self.curve_drag_active = False
-        invalidated_measurement = False
-        if self.angle_vector_1 is not None and self.angle_vector_1.references_node(
-            orientation, normalized_id
-        ):
-            self.angle_vector_1 = None
-            invalidated_measurement = True
-        if self.angle_vector_2 is not None and self.angle_vector_2.references_node(
-            orientation, normalized_id
-        ):
-            self.angle_vector_2 = None
-            invalidated_measurement = True
-        if invalidated_measurement:
-            self.calculated_angle_degrees = None
-        if (orientation, normalized_id) in self.angle_draft_nodes:
-            self._clear_angle_draft()
-
-    def invalidate_orientations(self, orientations: tuple[Orientation, ...]) -> None:
-        cleared = set(orientations)
-        if not cleared:
-            return
-        if self.pending_edge_orientation in cleared:
+        if self.pending_edge_node_id == normalized_id:
             self.cancel_pending_edge()
-        if self.selected_edge_orientation in cleared:
-            self.selected_edge_orientation = None
-            self.selected_edge = None
-            self.curve_drag_active = False
         measurement_invalidated = False
-        if self.angle_vector_1 is not None and self.angle_vector_1.orientation in cleared:
-            self.angle_vector_1 = None
-            measurement_invalidated = True
-        if self.angle_vector_2 is not None and self.angle_vector_2.orientation in cleared:
-            self.angle_vector_2 = None
-            measurement_invalidated = True
+        for vector_name in ("angle_vector_1", "angle_vector_2"):
+            vector = getattr(self, vector_name)
+            if vector is not None and normalized_id in (
+                vector.source_node_id,
+                vector.target_node_id,
+            ):
+                setattr(self, vector_name, None)
+                measurement_invalidated = True
         if measurement_invalidated:
             self.calculated_angle_degrees = None
-        self.cancel_active_tool()
+        if any(draft_id == normalized_id for _, draft_id in self.angle_draft_nodes):
+            self._clear_angle_draft()
 
     def exit_editing(self) -> None:
         self.editing_enabled = False
@@ -281,8 +286,7 @@ class ProjectionGraphState:
             "curve_drag_active": self.curve_drag_active,
             "pending_edge": (
                 None
-                if self.pending_edge_orientation is None
-                or self.pending_edge_node_id is None
+                if self.pending_edge_node_id is None
                 else {
                     "orientation": self.pending_edge_orientation,
                     "start_node_id": self.pending_edge_node_id,
@@ -292,24 +296,21 @@ class ProjectionGraphState:
                 "step": self.angle_selection_step,
                 "node_ids": [node_id for _, node_id in self.angle_draft_nodes],
                 "orientation": (
-                    None
-                    if not self.angle_draft_nodes
-                    else self.angle_draft_nodes[0][0]
+                    None if not self.angle_draft_nodes else self.angle_draft_nodes[0][0]
                 ),
             },
             "angle_vector_1": _vector_summary(self.angle_vector_1),
             "angle_vector_2": _vector_summary(self.angle_vector_2),
             "angle_degrees": self.calculated_angle_degrees,
-            "layers": {
-                orientation: {
-                    "plane_shape": (
-                        None if layer.plane_shape is None else list(layer.plane_shape)
-                    ),
-                    "num_nodes": len(layer.nodes),
-                    "num_edges": len(layer.edges),
-                    "num_curved_edges": len(layer.curve_control_points),
-                }
-                for orientation, layer in self.layers.items()
+            "voxel_graph": {
+                "volume_shape": (
+                    None
+                    if self.graph.volume_shape is None
+                    else list(self.graph.volume_shape)
+                ),
+                "num_nodes": len(self.graph.nodes),
+                "num_edges": len(self.graph.edges),
+                "num_curved_edges": len(self.graph.curve_control_points),
             },
         }
 
@@ -317,8 +318,13 @@ class ProjectionGraphState:
         self.angle_draft_nodes.clear()
         self.angle_selection_step = 0
 
+    def _clear_after_geometry_change(self) -> None:
+        self.cancel_pending_edge()
+        self.cancel_active_tool()
+        self.clear_angle()
+
     def _selected_edge_summary(self) -> dict[str, object] | None:
-        if self.selected_edge_orientation is None or self.selected_edge is None:
+        if self.selected_edge is None:
             return None
         return {
             "orientation": self.selected_edge_orientation,

--- a/src/mipview/graph/state.py
+++ b/src/mipview/graph/state.py
@@ -39,6 +39,12 @@ class ProjectionGraphState:
     angle_vector_1: DirectedGraphVector | None = None
     angle_vector_2: DirectedGraphVector | None = None
     calculated_angle_degrees: float | None = None
+    normal_line_orientation: Orientation | None = None
+    normal_line_edge: GraphEdge | None = None
+    normal_line_thickness: int = 1
+    extension_line_orientation: Orientation | None = None
+    extension_line_edge: GraphEdge | None = None
+    extension_line_thickness: int = 1
     _orientation_signature: tuple[float, ...] | None = field(
         default=None,
         repr=False,
@@ -114,6 +120,7 @@ class ProjectionGraphState:
     ) -> GraphEdge:
         edge = GraphEdge.between(first_node_id, second_node_id)
         self.graph.ensure_curve_control_point(edge)
+        self.invalidate_construction_lines(edge)
         self.active_tool = "curve_edge"
         self.selected_edge_orientation = orientation
         self.selected_edge = edge
@@ -243,6 +250,93 @@ class ProjectionGraphState:
         if self.active_tool == "calculate_angle":
             self.active_tool = None
 
+    def clear_graph(self) -> tuple[int, int]:
+        """Clear completed geometry and all interactions derived from it."""
+        node_count = len(self.graph.nodes)
+        edge_count = len(self.graph.edges)
+        self.graph.clear()
+        self.cancel_pending_edge()
+        self.cancel_active_tool()
+        self.clear_angle()
+        self.clear_normal_line()
+        self.clear_extension_line()
+        return node_count, edge_count
+
+    def set_normal_line(
+        self,
+        orientation: Orientation,
+        edge: GraphEdge,
+        visible: bool,
+    ) -> bool:
+        if visible:
+            if edge not in self.graph.edges:
+                raise ValueError(
+                    f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
+                )
+            if edge in self.graph.curve_control_points:
+                raise ValueError("A normal line is available only for a straight edge.")
+            self.normal_line_orientation = orientation
+            self.normal_line_edge = edge
+            return True
+        if (
+            self.normal_line_orientation == orientation
+            and self.normal_line_edge == edge
+        ):
+            self.clear_normal_line()
+        return False
+
+    def clear_normal_line(self) -> None:
+        self.normal_line_orientation = None
+        self.normal_line_edge = None
+
+    def set_extension_line(
+        self,
+        orientation: Orientation,
+        edge: GraphEdge,
+        visible: bool,
+    ) -> bool:
+        if visible:
+            if edge not in self.graph.edges:
+                raise ValueError(
+                    f"Graph edge {edge.start_node_id}-{edge.end_node_id} does not exist."
+                )
+            if edge in self.graph.curve_control_points:
+                raise ValueError(
+                    "An extension line is available only for a straight edge."
+                )
+            self.extension_line_orientation = orientation
+            self.extension_line_edge = edge
+            return True
+        if (
+            self.extension_line_orientation == orientation
+            and self.extension_line_edge == edge
+        ):
+            self.clear_extension_line()
+        return False
+
+    def clear_extension_line(self) -> None:
+        self.extension_line_orientation = None
+        self.extension_line_edge = None
+
+    def invalidate_edge(self, edge: GraphEdge) -> None:
+        if self.selected_edge == edge:
+            self.selected_edge_orientation = None
+            self.selected_edge = None
+            self.curve_drag_active = False
+        self.invalidate_construction_lines(edge)
+
+    def invalidate_construction_lines(self, edge: GraphEdge) -> None:
+        self.invalidate_normal_line(edge)
+        self.invalidate_extension_line(edge)
+
+    def invalidate_normal_line(self, edge: GraphEdge) -> None:
+        if self.normal_line_edge == edge:
+            self.clear_normal_line()
+
+    def invalidate_extension_line(self, edge: GraphEdge) -> None:
+        if self.extension_line_edge == edge:
+            self.clear_extension_line()
+
     def invalidate_node(self, node_id: int) -> None:
         normalized_id = int(node_id)
         if self.selected_edge is not None and normalized_id in (
@@ -254,6 +348,16 @@ class ProjectionGraphState:
             self.curve_drag_active = False
         if self.pending_edge_node_id == normalized_id:
             self.cancel_pending_edge()
+        if self.normal_line_edge is not None and normalized_id in (
+            self.normal_line_edge.start_node_id,
+            self.normal_line_edge.end_node_id,
+        ):
+            self.clear_normal_line()
+        if self.extension_line_edge is not None and normalized_id in (
+            self.extension_line_edge.start_node_id,
+            self.extension_line_edge.end_node_id,
+        ):
+            self.clear_extension_line()
         measurement_invalidated = False
         for vector_name in ("angle_vector_1", "angle_vector_2"):
             vector = getattr(self, vector_name)
@@ -302,6 +406,26 @@ class ProjectionGraphState:
             "angle_vector_1": _vector_summary(self.angle_vector_1),
             "angle_vector_2": _vector_summary(self.angle_vector_2),
             "angle_degrees": self.calculated_angle_degrees,
+            "normal_line": (
+                None
+                if self.normal_line_edge is None
+                else {
+                    "orientation": self.normal_line_orientation,
+                    "start_node_id": self.normal_line_edge.start_node_id,
+                    "end_node_id": self.normal_line_edge.end_node_id,
+                    "thickness": self.normal_line_thickness,
+                }
+            ),
+            "extension_line": (
+                None
+                if self.extension_line_edge is None
+                else {
+                    "orientation": self.extension_line_orientation,
+                    "start_node_id": self.extension_line_edge.start_node_id,
+                    "end_node_id": self.extension_line_edge.end_node_id,
+                    "thickness": self.extension_line_thickness,
+                }
+            ),
             "voxel_graph": {
                 "volume_shape": (
                     None
@@ -322,6 +446,8 @@ class ProjectionGraphState:
         self.cancel_pending_edge()
         self.cancel_active_tool()
         self.clear_angle()
+        self.clear_normal_line()
+        self.clear_extension_line()
 
     def _selected_edge_summary(self) -> dict[str, object] | None:
         if self.selected_edge is None:

--- a/src/mipview/segmentation/__init__.py
+++ b/src/mipview/segmentation/__init__.py
@@ -1,4 +1,8 @@
 from mipview.segmentation.models import LoadedSegmentation
+from mipview.segmentation.overlay import (
+    build_segmentation_overlay_rgba,
+    segmentation_label_color,
+)
 from mipview.segmentation.validation import (
     SegmentationValidationResult,
     validate_segmentation_compatibility,
@@ -6,6 +10,8 @@ from mipview.segmentation.validation import (
 
 __all__ = [
     "LoadedSegmentation",
+    "build_segmentation_overlay_rgba",
+    "segmentation_label_color",
     "SegmentationValidationResult",
     "validate_segmentation_compatibility",
 ]

--- a/src/mipview/segmentation/overlay.py
+++ b/src/mipview/segmentation/overlay.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import colorsys
+
+import numpy as np
+
+
+_GOLDEN_RATIO_CONJUGATE = 0.6180339887498949
+
+
+def build_segmentation_overlay_rgba(
+    label_slice: np.ndarray,
+    *,
+    opacity: float,
+) -> np.ndarray:
+    """Convert a 2D multi-label segmentation into a deterministic RGBA overlay."""
+    labels = np.asarray(label_slice)
+    if labels.ndim != 2:
+        raise ValueError(
+            f"Segmentation overlay expects a 2D label slice, got {labels.ndim}D."
+        )
+
+    overlay = np.zeros((*labels.shape, 4), dtype=np.uint8)
+    alpha_value = int(round(min(max(float(opacity), 0.0), 1.0) * 255.0))
+    foreground = np.isfinite(labels) & (labels > 0)
+    if alpha_value == 0 or not np.any(foreground):
+        return overlay
+
+    for raw_label in np.unique(labels[foreground]):
+        label_value = int(raw_label)
+        label_mask = labels == raw_label
+        overlay[label_mask, :3] = segmentation_label_color(label_value)
+        overlay[label_mask, 3] = alpha_value
+    return overlay
+
+
+def segmentation_label_color(label: int) -> np.ndarray:
+    """Return a stable high-contrast RGB color for a positive integer label."""
+    label_value = int(label)
+    if label_value <= 0:
+        raise ValueError("Segmentation label colors require a positive label.")
+    hue = ((label_value - 1) * _GOLDEN_RATIO_CONJUGATE) % 1.0
+    red, green, blue = colorsys.hsv_to_rgb(hue, 1.0, 1.0)
+    return np.asarray(
+        [round(red * 255.0), round(green * 255.0), round(blue * 255.0)],
+        dtype=np.uint8,
+    )

--- a/src/mipview/ui/graph_panel.py
+++ b/src/mipview/ui/graph_panel.py
@@ -23,6 +23,7 @@ class GraphPanel(QWidget):
     edge_thickness_changed = Signal(int)
     curve_tool_requested = Signal(bool)
     straighten_edge_requested = Signal()
+    clear_graph_requested = Signal()
     calculate_angle_requested = Signal()
     cancel_requested = Signal()
     clear_angle_requested = Signal()
@@ -88,6 +89,9 @@ class GraphPanel(QWidget):
         )
         tool_layout.addWidget(self.straighten_edge_button)
 
+        self.clear_graph_button = QPushButton("Clear All Nodes & Edges", group)
+        self.clear_graph_button.clicked.connect(self.clear_graph_requested.emit)
+
         self.calculate_angle_button = QPushButton("Calculate Angle", group)
         self.calculate_angle_button.clicked.connect(
             self.calculate_angle_requested.emit
@@ -112,6 +116,7 @@ class GraphPanel(QWidget):
         form.addRow("Node Size:", self.node_size_slider)
         form.addRow("Edge Thickness:", self.edge_thickness_slider)
         form.addRow("Curve:", tool_row)
+        form.addRow(self.clear_graph_button)
         form.addRow(self.calculate_angle_button)
         form.addRow(angle_action_row)
         form.addRow(self.angle_step_label)
@@ -129,6 +134,7 @@ class GraphPanel(QWidget):
             angle_selection_step=0,
             angle_degrees=None,
             has_angle_data=False,
+            has_graph_elements=False,
         )
 
     def set_projection_available(self, available: bool) -> None:
@@ -173,6 +179,7 @@ class GraphPanel(QWidget):
         angle_selection_step: int,
         angle_degrees: float | None,
         has_angle_data: bool,
+        has_graph_elements: bool,
     ) -> None:
         was_blocked = self.curve_edge_button.blockSignals(True)
         self.curve_edge_button.setChecked(active_tool == "curve_edge")
@@ -184,6 +191,7 @@ class GraphPanel(QWidget):
         self.clear_angle_button.setEnabled(
             bool(has_angle_data) or angle_selection_step > 0
         )
+        self.clear_graph_button.setEnabled(bool(has_graph_elements))
         prompts = (
             "Vector 1: select source node",
             "Vector 1: select target node",

--- a/src/mipview/ui/main_window.py
+++ b/src/mipview/ui/main_window.py
@@ -427,6 +427,7 @@ class MainWindow(QMainWindow):
                 if active_segmentation is not None and active_segmentation.kind == "file"
                 else None
             ),
+            projection_mask_layers=self._projection_mask_layers_for_bounds(bounds),
             segmentation_opacity=self.state.segmentation_opacity,
             annotation_mask=active_annotation_patch,
             annotation_opacity=self.state.annotation.opacity,
@@ -1251,6 +1252,7 @@ class MainWindow(QMainWindow):
             if self._active_segmentation_is_annotation()
             else self.state.segmentation_opacity
         )
+        self._update_patch_windows_projection_masks_for_current_image()
         self._sync_patch_windows_segmentation_menu_state()
 
     def _clear_segmentation_session(self) -> None:
@@ -1310,6 +1312,30 @@ class MainWindow(QMainWindow):
             patch_window.update_segmentation_overlay(
                 extract_patch(active_segmentation.volume, bounds),
                 opacity=self.state.segmentation_opacity,
+            )
+
+    def _projection_mask_layers_for_bounds(
+        self,
+        bounds: PatchBounds,
+    ) -> list[tuple[str, str, NiftiLoadResult]]:
+        return [
+            (
+                segmentation.id,
+                segmentation.display_name,
+                extract_patch(segmentation.volume, bounds),
+            )
+            for segmentation in self.state.loaded_segmentations
+            if segmentation.kind == "file"
+        ]
+
+    def _update_patch_windows_projection_masks_for_current_image(self) -> None:
+        for patch_window in self._patch_windows_for_current_image():
+            bounds = patch_window.source_patch_bounds()
+            if bounds is None:
+                patch_window.update_projection_mask_layers(())
+                continue
+            patch_window.update_projection_mask_layers(
+                self._projection_mask_layers_for_bounds(bounds)
             )
 
     def _sync_patch_windows_segmentation_menu_state(self) -> None:

--- a/src/mipview/ui/main_window.py
+++ b/src/mipview/ui/main_window.py
@@ -46,6 +46,7 @@ from mipview.ui.annotation_panel import AnnotationPanel
 from mipview.ui.cursor_panel import CursorInspectionPanel
 from mipview.ui.drop_load_choice_dialog import DropLoadChoice, DropLoadChoiceDialog
 from mipview.ui.drop_loading import first_supported_local_nifti_path
+from mipview.ui.overlay_opacity_control_bar import OverlayOpacityControlBar
 from mipview.ui.patch_window import PatchViewerWindow
 from mipview.ui.segmentation_config_window import SegmentationConfigWindow
 from mipview.ui.tool_actions import apply_tool_to_volume
@@ -83,6 +84,10 @@ class MainWindow(QMainWindow):
         self.cursor_panel = CursorInspectionPanel()
         self.annotation_panel = AnnotationPanel()
         self.contrast_control_bar = ContrastControlBar(self)
+        self.overlay_opacity_control_bar = OverlayOpacityControlBar(
+            self,
+            opacity=self.state.segmentation_opacity,
+        )
         self.cursor_overlay_action: QAction | None = None
         self.ruler_action: QAction | None = None
         self._cursor_overlay_checked_before_patch = True
@@ -103,6 +108,9 @@ class MainWindow(QMainWindow):
             self._on_active_segmentation_changed
         )
         self.segmentation_config_window.opacity_changed.connect(
+            self._on_segmentation_opacity_changed
+        )
+        self.overlay_opacity_control_bar.opacity_changed.connect(
             self._on_segmentation_opacity_changed
         )
         self.segmentation_config_window.unload_segmentation_requested.connect(
@@ -188,6 +196,7 @@ class MainWindow(QMainWindow):
         self._main_splitter = splitter
 
         content_layout.addWidget(self.contrast_control_bar)
+        content_layout.addWidget(self.overlay_opacity_control_bar)
         content_layout.addWidget(splitter, 1)
         self._setup_loading_progress_bar()
         content_layout.addWidget(self.loading_progress_bar)
@@ -427,6 +436,9 @@ class MainWindow(QMainWindow):
                 if active_segmentation is not None and active_segmentation.kind == "file"
                 else None
             ),
+            active_segmentation_kind=(
+                None if active_segmentation is None else active_segmentation.kind
+            ),
             projection_mask_layers=self._projection_mask_layers_for_bounds(bounds),
             segmentation_opacity=self.state.segmentation_opacity,
             annotation_mask=active_annotation_patch,
@@ -458,6 +470,9 @@ class MainWindow(QMainWindow):
         )
         patch_window.annotation_opacity_changed.connect(
             self._on_annotation_opacity_changed
+        )
+        patch_window.overlay_opacity_changed.connect(
+            self._on_segmentation_opacity_changed
         )
         patch_window.annotation_active_label_changed.connect(
             self._on_annotation_active_label_changed
@@ -1191,6 +1206,10 @@ class MainWindow(QMainWindow):
             self._on_annotation_opacity_changed(opacity)
             return
         self.state.segmentation_opacity = min(max(opacity, 0.0), 1.0)
+        self.segmentation_config_window.set_opacity(self.state.segmentation_opacity)
+        self.overlay_opacity_control_bar.set_opacity(
+            self.state.segmentation_opacity
+        )
         self.slice_viewer.set_segmentation_overlay_opacity(self.state.segmentation_opacity)
         self._update_patch_windows_segmentation_opacity_for_current_image()
 
@@ -1204,12 +1223,21 @@ class MainWindow(QMainWindow):
 
     def _apply_active_segmentation_overlay(self) -> None:
         active_segmentation = self._active_segmentation()
-        if active_segmentation is None or active_segmentation.kind == "annotation":
+        if active_segmentation is None:
             self.slice_viewer.set_segmentation_overlay(
                 None,
                 opacity=self.state.segmentation_opacity,
             )
             self._update_patch_windows_segmentation_for_current_image(None)
+            return
+        if active_segmentation.kind == "annotation":
+            self.slice_viewer.set_segmentation_overlay(
+                None,
+                opacity=self.state.segmentation_opacity,
+            )
+            self._update_patch_windows_segmentation_for_current_image(
+                active_segmentation
+            )
             return
         self.slice_viewer.set_segmentation_overlay(
             active_segmentation.volume,
@@ -1247,11 +1275,13 @@ class MainWindow(QMainWindow):
             ],
             self.state.active_segmentation_id,
         )
-        self.segmentation_config_window.set_opacity(
+        active_opacity = (
             self.state.annotation.opacity
             if self._active_segmentation_is_annotation()
             else self.state.segmentation_opacity
         )
+        self.segmentation_config_window.set_opacity(active_opacity)
+        self.overlay_opacity_control_bar.set_opacity(active_opacity)
         self._update_patch_windows_projection_masks_for_current_image()
         self._sync_patch_windows_segmentation_menu_state()
 
@@ -1307,11 +1337,17 @@ class MainWindow(QMainWindow):
                 patch_window.update_segmentation_overlay(
                     None,
                     opacity=self.state.segmentation_opacity,
+                    active_segmentation_kind=(
+                        None
+                        if active_segmentation is None
+                        else active_segmentation.kind
+                    ),
                 )
                 continue
             patch_window.update_segmentation_overlay(
                 extract_patch(active_segmentation.volume, bounds),
                 opacity=self.state.segmentation_opacity,
+                active_segmentation_kind=active_segmentation.kind,
             )
 
     def _projection_mask_layers_for_bounds(

--- a/src/mipview/ui/overlay_opacity_control_bar.py
+++ b/src/mipview/ui/overlay_opacity_control_bar.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QSlider, QWidget
+
+
+class OverlayOpacityControlBar(QWidget):
+    """Compact control for the active segmentation or annotation overlay."""
+
+    opacity_changed = Signal(float)
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        opacity: float = 0.5,
+    ) -> None:
+        super().__init__(parent)
+        self.opacity_label = QLabel("Overlay Opacity:", self)
+        self.opacity_slider = QSlider(Qt.Orientation.Horizontal, self)
+        self.opacity_slider.setRange(0, 100)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(12, 0, 12, 6)
+        layout.setSpacing(8)
+        layout.addWidget(self.opacity_label)
+        layout.addWidget(self.opacity_slider, 1)
+
+        self.opacity_slider.valueChanged.connect(
+            lambda value: self.opacity_changed.emit(value / 100.0)
+        )
+        self.set_opacity(opacity)
+
+    def set_opacity(self, opacity: float) -> None:
+        slider_value = int(round(min(max(float(opacity), 0.0), 1.0) * 100.0))
+        was_blocked = self.opacity_slider.blockSignals(True)
+        self.opacity_slider.setValue(slider_value)
+        self.opacity_slider.blockSignals(was_blocked)

--- a/src/mipview/ui/patch_window.py
+++ b/src/mipview/ui/patch_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from uuid import uuid4
 
@@ -101,6 +102,9 @@ class PatchViewerWindow(QMainWindow):
         source_patch_bounds: PatchBounds | None = None,
         patch_center: tuple[int, int, int] | None = None,
         patch_size: tuple[int, int, int] | None = None,
+        projection_mask_layers: Sequence[
+            tuple[str, str, NiftiLoadResult]
+        ] | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Selected Patch")
@@ -115,6 +119,7 @@ class PatchViewerWindow(QMainWindow):
         self._patch_data = patch_volume.data
         self._patch_volume = patch_volume
         self._segmentation_patch_volume = segmentation_volume
+        self._projection_mask_layers: dict[str, NiftiLoadResult] = {}
         self._annotation_patch_mask = annotation_mask
         self._annotation_opacity = min(max(float(annotation_opacity), 0.0), 1.0)
         self._annotation_visible = bool(annotation_visible)
@@ -275,6 +280,7 @@ class PatchViewerWindow(QMainWindow):
             self._on_auto_contrast,
         )
         self.slice_viewer.load_volume(patch_volume)
+        self.update_projection_mask_layers(projection_mask_layers or ())
         self.slice_viewer.set_projection_graph_state(self.graph_state)
         if segmentation_volume is not None:
             self.slice_viewer.set_segmentation_overlay(
@@ -373,6 +379,12 @@ class PatchViewerWindow(QMainWindow):
         self.projection_mode_combo.addItems(["MIP", "MinIP"])
         self.projection_mode_combo.currentTextChanged.connect(self._on_projection_mode_changed)
 
+        self.projection_mask_combo = QComboBox(panel)
+        self.projection_mask_combo.addItem("---", None)
+        self.projection_mask_combo.currentIndexChanged.connect(
+            self._on_projection_mask_changed
+        )
+
         direction_row = QWidget(panel)
         direction_layout = QHBoxLayout(direction_row)
         direction_layout.setContentsMargins(0, 0, 0, 0)
@@ -400,6 +412,7 @@ class PatchViewerWindow(QMainWindow):
         direction_layout.addWidget(self.sagittal_toggle_button)
 
         form.addRow("Mode:", self.projection_mode_combo)
+        form.addRow("Mask:", self.projection_mask_combo)
         form.addRow("Direction:", direction_row)
         return panel
 
@@ -433,6 +446,15 @@ class PatchViewerWindow(QMainWindow):
     def _on_projection_mode_changed(self, mode: str) -> None:
         self.slice_viewer.set_projection_mode(mode)
 
+    def _on_projection_mask_changed(self, _index: int) -> None:
+        segmentation_id = self.projection_mask_combo.currentData()
+        mask_volume = (
+            self._projection_mask_layers.get(segmentation_id)
+            if isinstance(segmentation_id, str)
+            else None
+        )
+        self.slice_viewer.set_projection_mask(mask_volume)
+
     def _on_projection_direction_toggled(self, orientation: str, enabled: bool) -> None:
         self.slice_viewer.set_projection_enabled(orientation, enabled)
 
@@ -460,6 +482,12 @@ class PatchViewerWindow(QMainWindow):
                     }
                 ),
                 "projection_mode": self.slice_viewer.projection_mode(),
+                "projection_mask_id": self.selected_projection_mask_id(),
+                "projection_mask_name": (
+                    None
+                    if self.selected_projection_mask_id() is None
+                    else self.projection_mask_combo.currentText()
+                ),
                 "enabled_orientations": list(
                     self.slice_viewer.enabled_projection_orientations()
                 ),
@@ -1551,10 +1579,23 @@ class PatchViewerWindow(QMainWindow):
             self._patch_volume.data,
             self._patch_volume.affine,
         ).display_data
+        selected_mask = self.selected_projection_mask_volume()
+        mask_data = (
+            None
+            if selected_mask is None
+            else build_oriented_volume(
+                selected_mask.data,
+                selected_mask.affine,
+            ).display_data
+        )
         planes: dict[str, np.ndarray | dict[str, np.ndarray]] = {
-            "axial": project_oriented_volume(volume, "axial", mode),
-            "coronal": project_oriented_volume(volume, "coronal", mode),
-            "sagittal": project_oriented_volume(volume, "sagittal", mode),
+            "axial": project_oriented_volume(volume, "axial", mode, mask=mask_data),
+            "coronal": project_oriented_volume(
+                volume, "coronal", mode, mask=mask_data
+            ),
+            "sagittal": project_oriented_volume(
+                volume, "sagittal", mode, mask=mask_data
+            ),
         }
         if self._segmentation_patch_volume is not None:
             segmentation_volume = build_oriented_volume(
@@ -1602,6 +1643,39 @@ class PatchViewerWindow(QMainWindow):
         self._segmentation_patch_volume = segmentation_volume
         self.slice_viewer.set_segmentation_overlay(segmentation_volume, opacity=opacity)
         self._refresh_seg_patch_save_enabled()
+
+    def update_projection_mask_layers(
+        self,
+        layers: Sequence[tuple[str, str, NiftiLoadResult]],
+    ) -> None:
+        """Refresh file-backed masks while preserving a still-loaded selection."""
+        selected_id = self.selected_projection_mask_id()
+        self._projection_mask_layers = {
+            segmentation_id: volume
+            for segmentation_id, _display_name, volume in layers
+        }
+
+        was_blocked = self.projection_mask_combo.blockSignals(True)
+        self.projection_mask_combo.clear()
+        self.projection_mask_combo.addItem("---", None)
+        selected_index = 0
+        for segmentation_id, display_name, _volume in layers:
+            self.projection_mask_combo.addItem(display_name, segmentation_id)
+            if segmentation_id == selected_id:
+                selected_index = self.projection_mask_combo.count() - 1
+        self.projection_mask_combo.setCurrentIndex(selected_index)
+        self.projection_mask_combo.blockSignals(was_blocked)
+        self._on_projection_mask_changed(selected_index)
+
+    def selected_projection_mask_id(self) -> str | None:
+        segmentation_id = self.projection_mask_combo.currentData()
+        return segmentation_id if isinstance(segmentation_id, str) else None
+
+    def selected_projection_mask_volume(self) -> NiftiLoadResult | None:
+        segmentation_id = self.selected_projection_mask_id()
+        if segmentation_id is None:
+            return None
+        return self._projection_mask_layers.get(segmentation_id)
 
     def update_segmentation_opacity(self, opacity: float) -> None:
         self.slice_viewer.set_segmentation_overlay_opacity(opacity)

--- a/src/mipview/ui/patch_window.py
+++ b/src/mipview/ui/patch_window.py
@@ -38,11 +38,16 @@ from PySide6.QtWidgets import (
 from mipview.annotation import AnnotationMask
 from mipview.annotation.annotation_overlay import build_annotation_overlay_rgba
 from mipview.graph import GraphEdge, GraphNode, ProjectionGraphState
-from mipview.graph.spatial import nearest_projected_edge_parameter
+from mipview.graph.spatial import (
+    extension_line_plane_endpoints,
+    nearest_projected_edge_parameter,
+    normal_line_plane_endpoints,
+)
 from mipview.io.nifti_io import NiftiLoadResult
 from mipview.patch.history import PatchHistoryManager
 from mipview.patch.saver import build_patch_default_filename, save_patch_nifti
 from mipview.patch.selector import PatchBounds
+from mipview.segmentation.overlay import build_segmentation_overlay_rgba
 from mipview.state.contrast_state import ContrastState
 from mipview.tools import derive_volume, get_tool
 from mipview.tools.patch_utility import patch_utility_from_tool
@@ -293,6 +298,7 @@ class PatchViewerWindow(QMainWindow):
         self.graph_panel.straighten_edge_requested.connect(
             self._on_graph_straighten_requested
         )
+        self.graph_panel.clear_graph_requested.connect(self.clear_graph)
         self.graph_panel.calculate_angle_requested.connect(
             self._on_graph_calculate_angle_requested
         )
@@ -768,6 +774,7 @@ class PatchViewerWindow(QMainWindow):
             first_node_id,
             second_node_id,
         )
+        self.graph_state.invalidate_construction_lines(edge)
         if (
             self.graph_state.selected_edge == edge
         ):
@@ -797,6 +804,7 @@ class PatchViewerWindow(QMainWindow):
             second_node_id,
             parameter,
         )
+        self.graph_state.invalidate_construction_lines(original_edge)
         if (
             self.graph_state.selected_edge == original_edge
         ):
@@ -828,12 +836,57 @@ class PatchViewerWindow(QMainWindow):
             second_node_id,
             control_point,
         )
+        self.graph_state.invalidate_construction_lines(edge)
         self.graph_state.active_orientation = orientation
         if self.graph_state.selected_edge == edge:
             self.graph_state.selected_edge_orientation = orientation
         self.slice_viewer.refresh_graph_overlay()
         self._refresh_graph_panel_tool_state()
         return edge
+
+    def set_graph_normal_line(
+        self,
+        orientation: Orientation,
+        first_node_id: int,
+        second_node_id: int,
+        visible: bool,
+    ) -> bool:
+        self._validate_graph_edit_operation(orientation)
+        edge = GraphEdge.between(first_node_id, second_node_id)
+        if visible:
+            normal_line_plane_endpoints(
+                self.slice_viewer.graph_projected_layer(orientation),
+                edge,
+            )
+        normal_visible = self.graph_state.set_normal_line(
+            orientation,
+            edge,
+            visible,
+        )
+        self.slice_viewer.refresh_graph_overlay()
+        return normal_visible
+
+    def set_graph_extension_line(
+        self,
+        orientation: Orientation,
+        first_node_id: int,
+        second_node_id: int,
+        visible: bool,
+    ) -> bool:
+        self._validate_graph_edit_operation(orientation)
+        edge = GraphEdge.between(first_node_id, second_node_id)
+        if visible:
+            extension_line_plane_endpoints(
+                self.slice_viewer.graph_projected_layer(orientation),
+                edge,
+            )
+        extension_visible = self.graph_state.set_extension_line(
+            orientation,
+            edge,
+            visible,
+        )
+        self.slice_viewer.refresh_graph_overlay()
+        return extension_visible
 
     def straighten_graph_edge(
         self,
@@ -887,6 +940,15 @@ class PatchViewerWindow(QMainWindow):
         self.slice_viewer.refresh_graph_overlay()
         self._refresh_graph_panel_tool_state()
         self.statusBar().showMessage("Graph angle cleared")
+
+    def clear_graph(self) -> tuple[int, int]:
+        node_count, edge_count = self.graph_state.clear_graph()
+        self.slice_viewer.refresh_graph_overlay()
+        self._refresh_graph_panel_tool_state()
+        self.statusBar().showMessage(
+            f"Cleared {node_count} graph node(s) and {edge_count} edge(s)"
+        )
+        return node_count, edge_count
 
     def _validate_graph_edit_operation(self, orientation: Orientation) -> None:
         self._validate_graph_editing()
@@ -1002,6 +1064,7 @@ class PatchViewerWindow(QMainWindow):
         elif hit_kind == "edge":
             start_node_id = int(hit["start_node_id"])
             end_node_id = int(hit["end_node_id"])
+            edge = GraphEdge.between(start_node_id, end_node_id)
             horizontal_index = int(projection_position[0])
             vertical_index = int(projection_position[1])
             create_node_action = menu.addAction("Create a node here")
@@ -1023,6 +1086,42 @@ class PatchViewerWindow(QMainWindow):
                 )
             )
             menu.addSeparator()
+            if edge not in self.graph_state.graph.curve_control_points:
+                normal_is_visible = (
+                    self.graph_state.normal_line_orientation == graph_orientation
+                    and self.graph_state.normal_line_edge == edge
+                )
+                normal_action = menu.addAction(
+                    "Hide the normal line"
+                    if normal_is_visible
+                    else "Display the normal line"
+                )
+                normal_action.triggered.connect(
+                    lambda _checked=False: self._set_graph_normal_line_from_ui(
+                        graph_orientation,
+                        start_node_id,
+                        end_node_id,
+                        not normal_is_visible,
+                    )
+                )
+                extension_is_visible = (
+                    self.graph_state.extension_line_orientation
+                    == graph_orientation
+                    and self.graph_state.extension_line_edge == edge
+                )
+                extension_action = menu.addAction(
+                    "Hide the extension line"
+                    if extension_is_visible
+                    else "Display the extension line"
+                )
+                extension_action.triggered.connect(
+                    lambda _checked=False: self._set_graph_extension_line_from_ui(
+                        graph_orientation,
+                        start_node_id,
+                        end_node_id,
+                        not extension_is_visible,
+                    )
+                )
             curve_action = menu.addAction("Curve Edge")
             curve_action.triggered.connect(
                 lambda _checked=False: self._select_graph_curve_from_ui(
@@ -1056,6 +1155,52 @@ class PatchViewerWindow(QMainWindow):
             )
         if not menu.isEmpty():
             menu.exec(global_position)
+
+    def _set_graph_normal_line_from_ui(
+        self,
+        orientation: Orientation,
+        start_node_id: int,
+        end_node_id: int,
+        visible: bool,
+    ) -> None:
+        try:
+            self.set_graph_normal_line(
+                orientation,
+                start_node_id,
+                end_node_id,
+                visible,
+            )
+        except ValueError as exc:
+            self.statusBar().showMessage(str(exc))
+            return
+        self.statusBar().showMessage(
+            "Displayed graph edge normal line"
+            if visible
+            else "Hid graph edge normal line"
+        )
+
+    def _set_graph_extension_line_from_ui(
+        self,
+        orientation: Orientation,
+        start_node_id: int,
+        end_node_id: int,
+        visible: bool,
+    ) -> None:
+        try:
+            self.set_graph_extension_line(
+                orientation,
+                start_node_id,
+                end_node_id,
+                visible,
+            )
+        except ValueError as exc:
+            self.statusBar().showMessage(str(exc))
+            return
+        self.statusBar().showMessage(
+            "Displayed graph edge extension line"
+            if visible
+            else "Hid graph edge extension line"
+        )
 
     def _add_graph_node_from_ui(
         self,
@@ -1351,6 +1496,9 @@ class PatchViewerWindow(QMainWindow):
             has_angle_data=(
                 self.graph_state.angle_vector_1 is not None
                 or self.graph_state.angle_vector_2 is not None
+            ),
+            has_graph_elements=bool(
+                self.graph_state.graph.nodes or self.graph_state.graph.edges
             ),
         )
 
@@ -1660,14 +1808,12 @@ class PatchViewerWindow(QMainWindow):
         target_width: int,
         target_height: int,
     ) -> None:
-        mask = np.asarray(plane) > 0
-        if not np.any(mask):
-            return
-        overlay = np.zeros((*mask.shape, 4), dtype=np.uint8)
-        overlay[..., 0] = 255
-        overlay[..., 3] = mask.astype(np.uint8) * int(
-            round(self.slice_viewer.segmentation_overlay_opacity() * 255.0)
+        overlay = build_segmentation_overlay_rgba(
+            plane,
+            opacity=self.slice_viewer.segmentation_overlay_opacity(),
         )
+        if not np.any(overlay[..., 3]):
+            return
         self._draw_rgba_export_overlay(
             painter, overlay, x_offset, y_offset, target_width, target_height
         )

--- a/src/mipview/ui/patch_window.py
+++ b/src/mipview/ui/patch_window.py
@@ -18,6 +18,7 @@ from PySide6.QtGui import (
     QShortcut,
 )
 from PySide6.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QFileDialog,
     QFormLayout,
@@ -37,6 +38,7 @@ from PySide6.QtWidgets import (
 from mipview.annotation import AnnotationMask
 from mipview.annotation.annotation_overlay import build_annotation_overlay_rgba
 from mipview.graph import GraphEdge, GraphNode, ProjectionGraphState
+from mipview.graph.spatial import nearest_projected_edge_parameter
 from mipview.io.nifti_io import NiftiLoadResult
 from mipview.patch.history import PatchHistoryManager
 from mipview.patch.saver import build_patch_default_filename, save_patch_nifti
@@ -53,6 +55,7 @@ from mipview.ui.contrast_control_bar import ContrastControlBar
 from mipview.ui.cursor_panel import CursorInspectionPanel
 from mipview.ui.annotation_panel import AnnotationPanel
 from mipview.ui.graph_panel import GraphPanel
+from mipview.ui.overlay_opacity_control_bar import OverlayOpacityControlBar
 from mipview.ui.patch_history_panel import PatchHistoryPanel
 from mipview.ui.tool_actions import apply_tool_to_volume_with_metadata
 from mipview.ui.tools_menu import build_tools_submenu
@@ -79,6 +82,7 @@ class PatchViewerWindow(QMainWindow):
     annotation_active_label_changed = Signal(int)
     annotation_brush_radius_changed = Signal(int)
     annotation_brush_mode_changed = Signal(str)
+    overlay_opacity_changed = Signal(float)
     unload_current_segmentation_requested = Signal()
     open_segmentation_configuration_requested = Signal()
 
@@ -105,6 +109,7 @@ class PatchViewerWindow(QMainWindow):
         projection_mask_layers: Sequence[
             tuple[str, str, NiftiLoadResult]
         ] | None = None,
+        active_segmentation_kind: str | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Selected Patch")
@@ -119,8 +124,22 @@ class PatchViewerWindow(QMainWindow):
         self._patch_data = patch_volume.data
         self._patch_volume = patch_volume
         self._segmentation_patch_volume = segmentation_volume
+        if active_segmentation_kind not in {None, "file", "annotation"}:
+            raise ValueError(
+                "Active segmentation kind must be file, annotation, or None."
+            )
+        self._active_segmentation_kind = active_segmentation_kind
+        if self._active_segmentation_kind is None:
+            if segmentation_volume is not None:
+                self._active_segmentation_kind = "file"
+            elif annotation_mask is not None:
+                self._active_segmentation_kind = "annotation"
         self._projection_mask_layers: dict[str, NiftiLoadResult] = {}
         self._annotation_patch_mask = annotation_mask
+        self._segmentation_opacity = min(
+            max(float(segmentation_opacity), 0.0),
+            1.0,
+        )
         self._annotation_opacity = min(max(float(annotation_opacity), 0.0), 1.0)
         self._annotation_visible = bool(annotation_visible)
         self._annotation_active_label = max(int(annotation_active_label), 0)
@@ -138,7 +157,18 @@ class PatchViewerWindow(QMainWindow):
         )
         self.contrast_state = ContrastState(self)
         self.contrast_control_bar = ContrastControlBar(self)
+        self.overlay_opacity_control_bar = OverlayOpacityControlBar(
+            self,
+            opacity=self._active_overlay_opacity(),
+        )
+        self.overlay_opacity_control_bar.opacity_changed.connect(
+            self._on_overlay_opacity_changed
+        )
         self.slice_viewer = TriPlanarViewerWidget(self)
+        self.slice_viewer.set_projection_segmentation_source(
+            self._active_segmentation_kind
+        )
+        self.slice_viewer.set_projection_segmentation_enabled(False)
         self.cursor_panel = CursorInspectionPanel(self, adaptable_width=True)
         self.cursor_panel.set_axis_directions(patch_volume.affine)
         self.cursor_panel.set_patch_controls_visible(False)
@@ -285,11 +315,11 @@ class PatchViewerWindow(QMainWindow):
         if segmentation_volume is not None:
             self.slice_viewer.set_segmentation_overlay(
                 segmentation_volume,
-                opacity=segmentation_opacity,
+                opacity=self._segmentation_opacity,
             )
         self.slice_viewer.set_annotation_overlay(
             annotation_mask,
-            opacity=annotation_opacity,
+            opacity=self._annotation_opacity,
             visible=annotation_visible,
             active_label=annotation_active_label,
         )
@@ -321,6 +351,7 @@ class PatchViewerWindow(QMainWindow):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self.contrast_control_bar)
+        layout.addWidget(self.overlay_opacity_control_bar)
         layout.addWidget(self._main_splitter, 1)
         apply_window_content_frame(self, central)
         self.setCentralWidget(central)
@@ -329,6 +360,15 @@ class PatchViewerWindow(QMainWindow):
         self._refresh_patch_history_panel()
 
     def _setup_menu(self) -> None:
+        view_menu = self.menuBar().addMenu("&View")
+        self.cursor_overlay_action = QAction("Show &Cursor Overlay", self)
+        self.cursor_overlay_action.setCheckable(True)
+        self.cursor_overlay_action.setChecked(True)
+        self.cursor_overlay_action.toggled.connect(
+            self.slice_viewer.set_cursor_overlay_visible
+        )
+        view_menu.addAction(self.cursor_overlay_action)
+
         self.segmentation_menu = self.menuBar().addMenu("&Segmentation")
         self.unload_current_segmentation_action = QAction(
             "&Unload Current Segmentation", self
@@ -385,6 +425,12 @@ class PatchViewerWindow(QMainWindow):
             self._on_projection_mask_changed
         )
 
+        self.projection_segmentation_checkbox = QCheckBox(panel)
+        self.projection_segmentation_checkbox.setChecked(False)
+        self.projection_segmentation_checkbox.toggled.connect(
+            self._on_projection_segmentation_toggled
+        )
+
         direction_row = QWidget(panel)
         direction_layout = QHBoxLayout(direction_row)
         direction_layout.setContentsMargins(0, 0, 0, 0)
@@ -413,6 +459,7 @@ class PatchViewerWindow(QMainWindow):
 
         form.addRow("Mode:", self.projection_mode_combo)
         form.addRow("Mask:", self.projection_mask_combo)
+        form.addRow("MIP the segmentation:", self.projection_segmentation_checkbox)
         form.addRow("Direction:", direction_row)
         return panel
 
@@ -433,6 +480,9 @@ class PatchViewerWindow(QMainWindow):
 
     def _sync_projection_controls(self) -> None:
         self.slice_viewer.set_projection_mode(self.projection_mode_combo.currentText())
+        self.slice_viewer.set_projection_segmentation_enabled(
+            self.projection_segmentation_checkbox.isChecked()
+        )
         self.slice_viewer.set_projection_enabled(
             "axial", self.axial_toggle_button.isChecked()
         )
@@ -454,6 +504,25 @@ class PatchViewerWindow(QMainWindow):
             else None
         )
         self.slice_viewer.set_projection_mask(mask_volume)
+
+    def _on_projection_segmentation_toggled(self, enabled: bool) -> None:
+        self.slice_viewer.set_projection_segmentation_enabled(enabled)
+
+    def _active_overlay_opacity(self) -> float:
+        if self._active_segmentation_kind == "annotation":
+            return self._annotation_opacity
+        return self._segmentation_opacity
+
+    def _on_overlay_opacity_changed(self, opacity: float) -> None:
+        normalized_opacity = min(max(float(opacity), 0.0), 1.0)
+        if self._active_segmentation_kind == "annotation":
+            self._annotation_opacity = normalized_opacity
+            self.slice_viewer.set_annotation_overlay_opacity(normalized_opacity)
+            self.annotation_panel.set_opacity(normalized_opacity)
+        else:
+            self._segmentation_opacity = normalized_opacity
+            self.slice_viewer.set_segmentation_overlay_opacity(normalized_opacity)
+        self.overlay_opacity_changed.emit(normalized_opacity)
 
     def _on_projection_direction_toggled(self, orientation: str, enabled: bool) -> None:
         self.slice_viewer.set_projection_enabled(orientation, enabled)
@@ -493,36 +562,94 @@ class PatchViewerWindow(QMainWindow):
                 ),
             }
         )
-        layers = summary["layers"]
-        assert isinstance(layers, dict)
+        voxel_graph = summary["voxel_graph"]
+        assert isinstance(voxel_graph, dict)
+        voxel_graph["nodes"] = [
+            self.graph_node_payload(node)
+            for node in sorted(
+                self.graph_state.graph.nodes.values(),
+                key=lambda node: node.id,
+            )
+        ]
+        voxel_graph["edges"] = [
+            {
+                "start_node_id": edge.start_node_id,
+                "end_node_id": edge.end_node_id,
+                "control_patch_voxel": (
+                    None
+                    if edge not in self.graph_state.graph.curve_control_points
+                    else [
+                        float(value)
+                        for value in self.graph_state.graph.curve_control_points[edge]
+                    ]
+                ),
+            }
+            for edge in sorted(self.graph_state.graph.edges)
+        ]
+        layers: dict[str, object] = {}
         for orientation in ("axial", "coronal", "sagittal"):
-            layer = self.graph_state.layer(orientation)
-            layer_summary = layers[orientation]
-            assert isinstance(layer_summary, dict)
-            layer_summary["nodes"] = [
-                {
-                    "id": node.id,
-                    "horizontal_index": node.horizontal_index,
-                    "vertical_index": node.vertical_index,
-                }
-                for node in sorted(layer.nodes.values(), key=lambda node: node.id)
-            ]
-            layer_summary["edges"] = [
-                {
-                    "start_node_id": edge.start_node_id,
-                    "end_node_id": edge.end_node_id,
-                    "control_point": (
-                        None
-                        if edge not in layer.curve_control_points
-                        else [
-                            float(layer.curve_control_points[edge][0]),
-                            float(layer.curve_control_points[edge][1]),
-                        ]
-                    ),
-                }
-                for edge in sorted(layer.edges)
-            ]
+            layer = self.slice_viewer.graph_projected_layer(orientation)
+            layers[orientation] = {
+                "plane_shape": list(layer.plane_shape),
+                "num_nodes": len(layer.nodes),
+                "num_edges": len(layer.edges),
+                "num_curved_edges": len(layer.curve_control_points),
+                "nodes": [
+                    {
+                        "id": node.id,
+                        "horizontal_index": _json_number(node.horizontal_index),
+                        "vertical_index": _json_number(node.vertical_index),
+                    }
+                    for node in sorted(layer.nodes.values(), key=lambda node: node.id)
+                ],
+                "edges": [
+                    {
+                        "start_node_id": edge.start_node_id,
+                        "end_node_id": edge.end_node_id,
+                        "control_point": (
+                            None
+                            if edge not in layer.curve_control_points
+                            else [
+                                float(layer.curve_control_points[edge][0]),
+                                float(layer.curve_control_points[edge][1]),
+                            ]
+                        ),
+                    }
+                    for edge in sorted(layer.edges)
+                ],
+            }
+        summary["layers"] = layers
         return summary
+
+    def graph_node_payload(
+        self,
+        node: GraphNode,
+        orientation: Orientation | None = None,
+    ) -> dict[str, object]:
+        projections: dict[str, list[int | float]] = {}
+        for view in ("axial", "coronal", "sagittal"):
+            projected = self.slice_viewer.graph_projected_layer(view).nodes[node.id]
+            projections[view] = [
+                _json_number(projected.horizontal_index),
+                _json_number(projected.vertical_index),
+            ]
+        source_voxel = None
+        if self._source_patch_bounds is not None:
+            source_voxel = [
+                node.x + self._source_patch_bounds.x_start,
+                node.y + self._source_patch_bounds.y_start,
+                node.z + self._source_patch_bounds.z_start,
+            ]
+        payload: dict[str, object] = {
+            "id": node.id,
+            "patch_voxel": list(node.position()),
+            "source_voxel": source_voxel,
+            "projections": projections,
+        }
+        if orientation is not None:
+            payload["horizontal_index"] = projections[orientation][0]
+            payload["vertical_index"] = projections[orientation][1]
+        return payload
 
     def set_graph_editing_enabled(self, enabled: bool) -> bool:
         target_enabled = bool(enabled)
@@ -584,23 +711,26 @@ class PatchViewerWindow(QMainWindow):
         vertical_index: int,
     ) -> GraphNode:
         self._validate_graph_edit_operation(orientation)
-        node = self.graph_state.layer(orientation).add_node(
+        voxel = self.slice_viewer.resolve_graph_projection_voxel(
+            orientation,
             horizontal_index,
             vertical_index,
         )
+        node = self.graph_state.graph.add_node(*voxel)
         self.graph_state.active_orientation = orientation
+        self.slice_viewer.refresh_graph_overlay()
+        return node
+
+    def add_graph_voxel_node(self, x: int, y: int, z: int) -> GraphNode:
+        self._validate_graph_editing()
+        node = self.graph_state.graph.add_node(x, y, z)
         self.slice_viewer.refresh_graph_overlay()
         return node
 
     def delete_graph_node(self, orientation: Orientation, node_id: int) -> GraphNode:
         self._validate_graph_edit_operation(orientation)
-        node = self.graph_state.layer(orientation).delete_node(node_id)
-        self.graph_state.invalidate_node(orientation, node.id)
-        if (
-            self.graph_state.pending_edge_orientation == orientation
-            and self.graph_state.pending_edge_node_id == node.id
-        ):
-            self.graph_state.cancel_pending_edge()
+        node = self.graph_state.graph.delete_node(node_id)
+        self.graph_state.invalidate_node(node.id)
         self.slice_viewer.refresh_graph_overlay()
         self._refresh_graph_panel_tool_state()
         return node
@@ -618,7 +748,7 @@ class PatchViewerWindow(QMainWindow):
         second_node_id: int,
     ) -> GraphEdge:
         self._validate_graph_edit_operation(orientation)
-        edge = self.graph_state.layer(orientation).add_edge(
+        edge = self.graph_state.graph.add_edge(
             first_node_id,
             second_node_id,
         )
@@ -634,13 +764,12 @@ class PatchViewerWindow(QMainWindow):
         second_node_id: int,
     ) -> GraphEdge:
         self._validate_graph_edit_operation(orientation)
-        edge = self.graph_state.layer(orientation).delete_edge(
+        edge = self.graph_state.graph.delete_edge(
             first_node_id,
             second_node_id,
         )
         if (
-            self.graph_state.selected_edge_orientation == orientation
-            and self.graph_state.selected_edge == edge
+            self.graph_state.selected_edge == edge
         ):
             self.graph_state.cancel_active_tool()
         self.slice_viewer.refresh_graph_overlay()
@@ -657,14 +786,19 @@ class PatchViewerWindow(QMainWindow):
     ) -> tuple[GraphNode, GraphEdge, GraphEdge]:
         self._validate_graph_edit_operation(orientation)
         original_edge = GraphEdge.between(first_node_id, second_node_id)
-        result = self.graph_state.layer(orientation).split_edge(
-            first_node_id,
-            second_node_id,
+        projected_layer = self.slice_viewer.graph_projected_layer(orientation)
+        parameter = nearest_projected_edge_parameter(
+            projected_layer,
+            original_edge,
             (horizontal_index, vertical_index),
         )
+        result = self.graph_state.graph.split_edge_at_parameter(
+            first_node_id,
+            second_node_id,
+            parameter,
+        )
         if (
-            self.graph_state.selected_edge_orientation == orientation
-            and self.graph_state.selected_edge == original_edge
+            self.graph_state.selected_edge == original_edge
         ):
             self.graph_state.cancel_active_tool()
         self.graph_state.active_orientation = orientation
@@ -681,13 +815,22 @@ class PatchViewerWindow(QMainWindow):
         control_vertical: float,
     ) -> GraphEdge:
         self._validate_graph_edit_operation(orientation)
-        layer = self.graph_state.layer(orientation)
-        edge = layer.set_curve_control_point(
+        edge = GraphEdge.between(first_node_id, second_node_id)
+        current_control = self.graph_state.graph.curve_control_point_or_midpoint(edge)
+        control_point = self.slice_viewer.graph_control_point_from_projection(
+            current_control,
+            orientation,
+            control_horizontal,
+            control_vertical,
+        )
+        edge = self.graph_state.graph.set_curve_control_point(
             first_node_id,
             second_node_id,
-            (control_horizontal, control_vertical),
+            control_point,
         )
         self.graph_state.active_orientation = orientation
+        if self.graph_state.selected_edge == edge:
+            self.graph_state.selected_edge_orientation = orientation
         self.slice_viewer.refresh_graph_overlay()
         self._refresh_graph_panel_tool_state()
         return edge
@@ -699,14 +842,11 @@ class PatchViewerWindow(QMainWindow):
         second_node_id: int,
     ) -> GraphEdge:
         self._validate_graph_edit_operation(orientation)
-        edge = self.graph_state.layer(orientation).straighten_edge(
+        edge = self.graph_state.graph.straighten_edge(
             first_node_id,
             second_node_id,
         )
-        if (
-            self.graph_state.selected_edge_orientation == orientation
-            and self.graph_state.selected_edge == edge
-        ):
+        if self.graph_state.selected_edge == edge:
             self.graph_state.selected_edge = None
             self.graph_state.selected_edge_orientation = None
             self.graph_state.curve_drag_active = False
@@ -729,6 +869,12 @@ class PatchViewerWindow(QMainWindow):
             vector_1_target,
             vector_2_source,
             vector_2_target,
+            {
+                node.id: node.position()
+                for node in self.slice_viewer.graph_projected_layer(
+                    orientation
+                ).nodes.values()
+            },
             self._graph_in_plane_spacing(orientation),
         )
         self.graph_state.active_orientation = orientation
@@ -743,14 +889,19 @@ class PatchViewerWindow(QMainWindow):
         self.statusBar().showMessage("Graph angle cleared")
 
     def _validate_graph_edit_operation(self, orientation: Orientation) -> None:
-        if not self.graph_state.editing_enabled:
-            raise ValueError("Graph mode is not active.")
-        if not self.graph_state.visible:
-            raise ValueError("Graph visibility must be enabled before editing.")
+        self._validate_graph_editing()
         if not self.slice_viewer.projection_enabled(orientation):
             raise ValueError(
                 f"The {orientation} viewer is not showing a MIP/MinIP projection."
             )
+
+    def _validate_graph_editing(self) -> None:
+        if not self.graph_state.editing_enabled:
+            raise ValueError("Graph mode is not active.")
+        if not self.graph_state.visible:
+            raise ValueError("Graph visibility must be enabled before editing.")
+        if not self.slice_viewer.enabled_projection_orientations():
+            raise ValueError("Enable at least one MIP/MinIP projection first.")
 
     def _on_graph_activation_requested(self) -> None:
         try:
@@ -883,7 +1034,7 @@ class PatchViewerWindow(QMainWindow):
             straighten_action = menu.addAction("Straighten Edge")
             straighten_action.setEnabled(
                 GraphEdge.between(start_node_id, end_node_id)
-                in self.graph_state.layer(graph_orientation).curve_control_points
+                in self.graph_state.graph.curve_control_points
             )
             straighten_action.triggered.connect(
                 lambda _checked=False: self._straighten_graph_edge_from_ui(
@@ -958,16 +1109,13 @@ class PatchViewerWindow(QMainWindow):
     ) -> None:
         pending_orientation = self.graph_state.pending_edge_orientation
         pending_node_id = self.graph_state.pending_edge_node_id
-        if pending_orientation is None or pending_node_id is None:
+        if pending_node_id is None:
             return
-        if orientation != pending_orientation:
-            self.statusBar().showMessage(
-                "Graph edges must connect nodes in the same orientation"
-            )
+        if orientation not in ("axial", "coronal", "sagittal"):
             return
         try:
             edge = self.add_graph_edge(
-                pending_orientation,
+                orientation,  # type: ignore[arg-type]
                 pending_node_id,
                 node_id,
             )
@@ -976,7 +1124,8 @@ class PatchViewerWindow(QMainWindow):
             return
         self.statusBar().showMessage(
             "Created graph edge "
-            f"{edge.start_node_id}-{edge.end_node_id} in {pending_orientation}"
+            f"{edge.start_node_id}-{edge.end_node_id} from {pending_orientation} "
+            f"to {orientation}"
         )
 
     def _delete_graph_edge_from_ui(
@@ -1095,10 +1244,12 @@ class PatchViewerWindow(QMainWindow):
         if orientation not in ("axial", "coronal", "sagittal"):
             return
         try:
-            self.graph_state.layer(orientation).set_curve_control_point(
+            self.curve_graph_edge(
+                orientation,  # type: ignore[arg-type]
                 start_node_id,
                 end_node_id,
-                (horizontal, vertical),
+                horizontal,
+                vertical,
             )
         except ValueError as exc:
             self.statusBar().showMessage(str(exc))
@@ -1116,6 +1267,12 @@ class PatchViewerWindow(QMainWindow):
             angle = self.graph_state.select_angle_node(
                 orientation,  # type: ignore[arg-type]
                 node_id,
+                {
+                    node.id: node.position()
+                    for node in self.slice_viewer.graph_projected_layer(
+                        orientation  # type: ignore[arg-type]
+                    ).nodes.values()
+                },
                 self._graph_in_plane_spacing(orientation),  # type: ignore[arg-type]
             )
         except ValueError as exc:
@@ -1181,15 +1338,10 @@ class PatchViewerWindow(QMainWindow):
 
     def _refresh_graph_panel_tool_state(self) -> None:
         selected_curved = False
-        if (
-            self.graph_state.selected_edge_orientation is not None
-            and self.graph_state.selected_edge is not None
-        ):
+        if self.graph_state.selected_edge is not None:
             selected_curved = (
                 self.graph_state.selected_edge
-                in self.graph_state.layer(
-                    self.graph_state.selected_edge_orientation
-                ).curve_control_points
+                in self.graph_state.graph.curve_control_points
             )
         self.graph_panel.set_tool_state(
             active_tool=self.graph_state.active_tool,
@@ -1597,17 +1749,25 @@ class PatchViewerWindow(QMainWindow):
                 volume, "sagittal", mode, mask=mask_data
             ),
         }
-        if self._segmentation_patch_volume is not None:
+        if (
+            self.projection_segmentation_checkbox.isChecked()
+            and self._active_segmentation_kind == "file"
+            and self._segmentation_patch_volume is not None
+        ):
             segmentation_volume = build_oriented_volume(
                 self._segmentation_patch_volume.data,
                 self._segmentation_patch_volume.affine,
             ).display_data
             planes["segmentation"] = {
-                "axial": project_oriented_volume(segmentation_volume, "axial", mode),
-                "coronal": project_oriented_volume(segmentation_volume, "coronal", mode),
-                "sagittal": project_oriented_volume(segmentation_volume, "sagittal", mode),
+                "axial": project_oriented_volume(segmentation_volume, "axial", "MIP"),
+                "coronal": project_oriented_volume(segmentation_volume, "coronal", "MIP"),
+                "sagittal": project_oriented_volume(segmentation_volume, "sagittal", "MIP"),
             }
-        if self._annotation_patch_mask is not None:
+        if (
+            self.projection_segmentation_checkbox.isChecked()
+            and self._active_segmentation_kind == "annotation"
+            and self._annotation_patch_mask is not None
+        ):
             annotation_volume = build_oriented_volume(
                 self._annotation_patch_mask.data,
                 self._annotation_patch_mask.affine,
@@ -1639,9 +1799,28 @@ class PatchViewerWindow(QMainWindow):
         self,
         segmentation_volume: NiftiLoadResult | None,
         opacity: float,
+        *,
+        active_segmentation_kind: str | None = None,
     ) -> None:
+        if active_segmentation_kind not in {None, "file", "annotation"}:
+            raise ValueError(
+                "Active segmentation kind must be file, annotation, or None."
+            )
+        if active_segmentation_kind is None and segmentation_volume is not None:
+            active_segmentation_kind = "file"
+        self._segmentation_opacity = min(max(float(opacity), 0.0), 1.0)
         self._segmentation_patch_volume = segmentation_volume
-        self.slice_viewer.set_segmentation_overlay(segmentation_volume, opacity=opacity)
+        self._active_segmentation_kind = active_segmentation_kind
+        self.slice_viewer.set_projection_segmentation_source(
+            self._active_segmentation_kind
+        )
+        self.overlay_opacity_control_bar.set_opacity(
+            self._active_overlay_opacity()
+        )
+        self.slice_viewer.set_segmentation_overlay(
+            segmentation_volume,
+            opacity=self._segmentation_opacity,
+        )
         self._refresh_seg_patch_save_enabled()
 
     def update_projection_mask_layers(
@@ -1678,7 +1857,14 @@ class PatchViewerWindow(QMainWindow):
         return self._projection_mask_layers.get(segmentation_id)
 
     def update_segmentation_opacity(self, opacity: float) -> None:
-        self.slice_viewer.set_segmentation_overlay_opacity(opacity)
+        self._segmentation_opacity = min(max(float(opacity), 0.0), 1.0)
+        self.slice_viewer.set_segmentation_overlay_opacity(
+            self._segmentation_opacity
+        )
+        if self._active_segmentation_kind != "annotation":
+            self.overlay_opacity_control_bar.set_opacity(
+                self._segmentation_opacity
+            )
 
     def update_annotation_overlay(
         self,
@@ -1697,7 +1883,7 @@ class PatchViewerWindow(QMainWindow):
         self._annotation_active_label = max(int(active_label), 0)
         self.slice_viewer.set_annotation_overlay(
             annotation_mask,
-            opacity=opacity,
+            opacity=self._annotation_opacity,
             visible=visible,
             active_label=active_label,
         )
@@ -1710,6 +1896,10 @@ class PatchViewerWindow(QMainWindow):
             brush_radius=brush_radius,
             brush_mode=brush_mode,
         )
+        if self._active_segmentation_kind == "annotation":
+            self.overlay_opacity_control_bar.set_opacity(
+                self._annotation_opacity
+            )
         self._refresh_seg_patch_save_enabled()
 
     def update_annotation_display_options(
@@ -1724,12 +1914,16 @@ class PatchViewerWindow(QMainWindow):
         self._annotation_opacity = min(max(float(opacity), 0.0), 1.0)
         self._annotation_visible = bool(visible)
         self._annotation_active_label = max(int(active_label), 0)
-        self.slice_viewer.set_annotation_overlay_opacity(opacity)
+        self.slice_viewer.set_annotation_overlay_opacity(self._annotation_opacity)
         self.slice_viewer.set_annotation_overlay_visible(visible)
         self.slice_viewer.set_annotation_active_label(active_label)
         self.annotation_panel.set_visible_checked(visible)
         self.annotation_panel.set_opacity(opacity)
         self.annotation_panel.set_active_label(active_label)
+        if self._active_segmentation_kind == "annotation":
+            self.overlay_opacity_control_bar.set_opacity(
+                self._annotation_opacity
+            )
         if brush_radius is not None:
             self.slice_viewer.set_annotation_brush_radius(brush_radius)
             self.annotation_panel.set_brush_radius(brush_radius)
@@ -1921,3 +2115,10 @@ class PatchViewerWindow(QMainWindow):
     def resizeEvent(self, event: QResizeEvent) -> None:
         super().resizeEvent(event)
         self._font_scaler.apply()
+
+
+def _json_number(value: float) -> int | float:
+    rounded = round(float(value))
+    if abs(float(value) - rounded) < 1e-9:
+        return int(rounded)
+    return float(value)

--- a/src/mipview/ui/segmentation_config_window.py
+++ b/src/mipview/ui/segmentation_config_window.py
@@ -42,7 +42,7 @@ class SegmentationConfigWindow(QMainWindow):
             self._on_segmentation_context_menu_requested
         )
 
-        self.opacity_label = QLabel("Overlay Opacity", container)
+        self.opacity_label = QLabel("Overlay Opacity:", container)
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal, container)
         self.opacity_slider.setRange(0, 100)
         self.opacity_slider.setValue(50)

--- a/src/mipview/viewer/intensity.py
+++ b/src/mipview/viewer/intensity.py
@@ -6,14 +6,21 @@ import numpy as np
 def normalize_slice_to_uint8(slice_data: np.ndarray) -> np.ndarray:
     """Normalize a 2D slice to 8-bit grayscale for display."""
     float_slice = np.asarray(slice_data, dtype=np.float32)
-    min_value = float(float_slice.min())
-    max_value = float(float_slice.max())
+    finite_mask = np.isfinite(float_slice)
+    finite_values = float_slice[finite_mask]
+    if finite_values.size == 0:
+        return np.zeros(float_slice.shape, dtype=np.uint8)
+
+    min_value = float(finite_values.min())
+    max_value = float(finite_values.max())
 
     if max_value <= min_value:
         return np.zeros(float_slice.shape, dtype=np.uint8)
 
-    scaled = (float_slice - min_value) / (max_value - min_value)
-    return np.clip(scaled * 255.0, 0.0, 255.0).astype(np.uint8)
+    output = np.zeros(float_slice.shape, dtype=np.uint8)
+    scaled = (finite_values - min_value) / (max_value - min_value)
+    output[finite_mask] = np.clip(scaled * 255.0, 0.0, 255.0).astype(np.uint8)
+    return output
 
 
 def window_slice_to_uint8(
@@ -24,8 +31,11 @@ def window_slice_to_uint8(
     if window_max <= window_min:
         return np.zeros(float_slice.shape, dtype=np.uint8)
 
-    scaled = (float_slice - window_min) / (window_max - window_min)
-    return np.clip(scaled * 255.0, 0.0, 255.0).astype(np.uint8)
+    finite_mask = np.isfinite(float_slice)
+    output = np.zeros(float_slice.shape, dtype=np.uint8)
+    scaled = (float_slice[finite_mask] - window_min) / (window_max - window_min)
+    output[finite_mask] = np.clip(scaled * 255.0, 0.0, 255.0).astype(np.uint8)
+    return output
 
 
 def volume_intensity_range(volume_data: np.ndarray) -> tuple[float, float]:

--- a/src/mipview/viewer/slice_geometry.py
+++ b/src/mipview/viewer/slice_geometry.py
@@ -126,17 +126,50 @@ def extract_oriented_slice(
 
 
 def project_oriented_volume(
-    volume: np.ndarray, orientation: Orientation, mode: str
+    volume: np.ndarray,
+    orientation: Orientation,
+    mode: str,
+    mask: np.ndarray | None = None,
 ) -> np.ndarray:
-    """Project canonical RAS data using the same display orientation rules as slices."""
+    """Project canonical RAS data using the same display orientation rules as slices.
+
+    When ``mask`` is provided, only non-zero mask voxels contribute to each
+    projection ray. Rays without any masked voxels are returned as NaN so the
+    display layer can render them as black without inventing an image intensity.
+    """
     normalized_mode = mode.strip().upper()
     reducer = np.max if normalized_mode == "MIP" else np.min
+    projection_volume = np.asarray(volume)
+    projection_mask = None
+    if mask is not None:
+        projection_mask = np.asarray(mask)
+        if projection_mask.shape != projection_volume.shape:
+            raise ValueError(
+                "Projection mask shape must match the projected volume shape."
+            )
+        projection_mask = projection_mask != 0
+
+    def reduce_axis(axis: int) -> np.ndarray:
+        if projection_mask is None:
+            return reducer(projection_volume, axis=axis)
+
+        fill_value = -np.inf if normalized_mode == "MIP" else np.inf
+        masked_volume = np.where(
+            projection_mask,
+            np.asarray(projection_volume, dtype=np.float64),
+            fill_value,
+        )
+        projection = reducer(masked_volume, axis=axis)
+        valid_rays = np.any(projection_mask, axis=axis)
+        projection[~valid_rays] = np.nan
+        return projection
+
     if orientation == "axial":
-        return reducer(volume, axis=2).T[::-1, ::-1]
+        return reduce_axis(2).T[::-1, ::-1]
     if orientation == "coronal":
-        return reducer(volume, axis=1).T[::-1, ::-1]
+        return reduce_axis(1).T[::-1, ::-1]
     if orientation == "sagittal":
-        return reducer(volume, axis=0).T[::-1, ::-1]
+        return reduce_axis(0).T[::-1, ::-1]
     raise ValueError(f"Unsupported orientation: {orientation}")
 
 

--- a/src/mipview/viewer/slice_viewer_widget.py
+++ b/src/mipview/viewer/slice_viewer_widget.py
@@ -784,13 +784,14 @@ class SliceViewerWidget(QWidget):
         node_hits = [
             (
                 float(np.hypot(label_position.x() - point.x(), label_position.y() - point.y())),
+                self._graph_layer.node_hit_priorities.get(node_id, 1),
                 node_id,
             )
             for node_id, point in node_positions.items()
         ]
         node_hits = [hit for hit in node_hits if hit[0] <= node_tolerance]
         if node_hits:
-            _, node_id = min(node_hits)
+            _, _, node_id = min(node_hits)
             return {"kind": "node", "node_id": node_id}
 
         edge_tolerance = max((self._graph_edge_thickness / 2.0) + 4.0, 6.0)

--- a/src/mipview/viewer/slice_viewer_widget.py
+++ b/src/mipview/viewer/slice_viewer_widget.py
@@ -23,7 +23,12 @@ from mipview.graph.curve import point_to_quadratic_bezier_distance
 from mipview.graph.geometry import point_to_segment_distance
 from mipview.graph.measurement import DirectedGraphVector
 from mipview.graph.model import GraphEdge, ProjectionGraphLayer
+from mipview.graph.spatial import (
+    extension_line_plane_endpoints,
+    normal_line_plane_endpoints,
+)
 from mipview.viewer.intensity import normalize_slice_to_uint8, window_slice_to_uint8
+from mipview.segmentation.overlay import build_segmentation_overlay_rgba
 from mipview.viewer.oriented_volume import OrientedVolume
 from mipview.viewer.ruler import display_voxel_spacing_mm, select_ruler_geometry
 from mipview.patch.selector import (
@@ -119,6 +124,10 @@ class SliceViewerWidget(QWidget):
         self._graph_selected_edge: GraphEdge | None = None
         self._graph_curve_handle_visible = False
         self._graph_angle_vectors: tuple[DirectedGraphVector, ...] = ()
+        self._graph_normal_line_edge: GraphEdge | None = None
+        self._graph_normal_line_thickness = 1
+        self._graph_extension_line_edge: GraphEdge | None = None
+        self._graph_extension_line_thickness = 1
         self._active_patch_resize_handle: str | None = None
         self._interaction_mode: str | None = None
         self._last_drag_position: QPointF | None = None
@@ -240,6 +249,10 @@ class SliceViewerWidget(QWidget):
         selected_edge: GraphEdge | None,
         curve_handle_visible: bool,
         angle_vectors: tuple[DirectedGraphVector, ...],
+        normal_line_edge: GraphEdge | None = None,
+        normal_line_thickness: int = 1,
+        extension_line_edge: GraphEdge | None = None,
+        extension_line_thickness: int = 1,
     ) -> None:
         self._graph_layer = layer
         self._graph_editing_enabled = bool(editing_enabled)
@@ -254,6 +267,13 @@ class SliceViewerWidget(QWidget):
         self._graph_selected_edge = selected_edge
         self._graph_curve_handle_visible = bool(curve_handle_visible)
         self._graph_angle_vectors = tuple(angle_vectors)
+        self._graph_normal_line_edge = normal_line_edge
+        self._graph_normal_line_thickness = max(int(normal_line_thickness), 1)
+        self._graph_extension_line_edge = extension_line_edge
+        self._graph_extension_line_thickness = max(
+            int(extension_line_thickness),
+            1,
+        )
         if self._graph_pending_node_id is None:
             self._graph_preview_label_position = None
         self._update_scaled_pixmap()
@@ -581,6 +601,7 @@ class SliceViewerWidget(QWidget):
 
         painter.save()
         painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        self._draw_graph_extension_line(painter, display_rect, alpha)
         edge_pen = QPen(edge_color, self._graph_edge_thickness)
         edge_pen.setCosmetic(True)
         painter.setPen(edge_pen)
@@ -601,6 +622,7 @@ class SliceViewerWidget(QWidget):
                     path.quadTo(control_position, end)
                     painter.drawPath(path)
 
+        self._draw_graph_normal_line(painter, display_rect, alpha)
         self._draw_graph_angle_vectors(painter, node_positions, alpha)
 
         painter.setPen(Qt.PenStyle.NoPen)
@@ -641,6 +663,62 @@ class SliceViewerWidget(QWidget):
                 painter.setBrush(Qt.BrushStyle.NoBrush)
                 painter.drawLine(start, self._graph_preview_label_position)
         painter.restore()
+
+    def _draw_graph_extension_line(
+        self,
+        painter: QPainter,
+        display_rect: DisplayRect,
+        alpha: int,
+    ) -> None:
+        if self._graph_layer is None or self._graph_extension_line_edge is None:
+            return
+        try:
+            first, second = extension_line_plane_endpoints(
+                self._graph_layer,
+                self._graph_extension_line_edge,
+            )
+        except ValueError:
+            return
+        extension_pen = QPen(
+            QColor(0, 191, 255, alpha),
+            self._graph_extension_line_thickness,
+        )
+        extension_pen.setCosmetic(True)
+        extension_pen.setStyle(Qt.PenStyle.DashLine)
+        painter.setPen(extension_pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawLine(
+            self._graph_projection_point_to_screen(first, display_rect),
+            self._graph_projection_point_to_screen(second, display_rect),
+        )
+
+    def _draw_graph_normal_line(
+        self,
+        painter: QPainter,
+        display_rect: DisplayRect,
+        alpha: int,
+    ) -> None:
+        if self._graph_layer is None or self._graph_normal_line_edge is None:
+            return
+        try:
+            first, second = normal_line_plane_endpoints(
+                self._graph_layer,
+                self._graph_normal_line_edge,
+            )
+        except ValueError:
+            return
+        normal_pen = QPen(
+            QColor(255, 255, 0, alpha),
+            self._graph_normal_line_thickness,
+        )
+        normal_pen.setCosmetic(True)
+        normal_pen.setStyle(Qt.PenStyle.DashLine)
+        painter.setPen(normal_pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawLine(
+            self._graph_projection_point_to_screen(first, display_rect),
+            self._graph_projection_point_to_screen(second, display_rect),
+        )
 
     def _draw_graph_angle_vectors(
         self,
@@ -939,17 +1017,14 @@ class SliceViewerWidget(QWidget):
                 self.orientation,
                 display_cursor,
             )
-        segmentation_mask = np.asarray(segmentation_slice) > 0
-        if not np.any(segmentation_mask):
+        overlay = build_segmentation_overlay_rgba(
+            segmentation_slice,
+            opacity=self._segmentation_overlay_opacity,
+        )
+        if not np.any(overlay[..., 3]):
             return
 
-        height, width = segmentation_mask.shape
-        overlay = np.zeros((height, width, 4), dtype=np.uint8)
-        overlay[..., 0] = 255
-        overlay[..., 3] = (
-            segmentation_mask.astype(np.uint8)
-            * int(round(self._segmentation_overlay_opacity * 255.0))
-        )
+        height, width = overlay.shape[:2]
         overlay_contiguous = np.ascontiguousarray(overlay)
         overlay_image = QImage(
             overlay_contiguous.data,

--- a/src/mipview/viewer/triplanar_viewer_widget.py
+++ b/src/mipview/viewer/triplanar_viewer_widget.py
@@ -68,6 +68,7 @@ class TriPlanarViewerWidget(QWidget):
         super().__init__(parent)
         self._display_volume: OrientedVolume | None = None
         self._segmentation_display_volume: OrientedVolume | None = None
+        self._projection_mask_display_volume: OrientedVolume | None = None
         self._segmentation_opacity: float = 0.5
         self._annotation_mask: AnnotationMask | None = None
         self._annotation_display_volume: OrientedVolume | None = None
@@ -229,6 +230,7 @@ class TriPlanarViewerWidget(QWidget):
     def unload_volume(self) -> None:
         self._display_volume = None
         self._segmentation_display_volume = None
+        self._projection_mask_display_volume = None
         self._annotation_mask = None
         self._annotation_display_volume = None
         self._annotation_editing_enabled = False
@@ -476,6 +478,29 @@ class TriPlanarViewerWidget(QWidget):
 
     def segmentation_overlay_opacity(self) -> float:
         return self._segmentation_opacity
+
+    def set_projection_mask(self, mask_volume: NiftiLoadResult | None) -> None:
+        """Restrict MIP/MinIP calculations to non-zero voxels in ``mask_volume``."""
+        if mask_volume is None:
+            self._projection_mask_display_volume = None
+            self._update_projection_overrides()
+            return
+
+        if mask_volume.data.ndim != 3:
+            raise ValueError(
+                f"Projection mask expects a 3D volume, got {mask_volume.data.ndim}D."
+            )
+        if (
+            self._display_volume is not None
+            and mask_volume.shape != self._display_volume.source_shape
+        ):
+            raise ValueError("Projection mask shape does not match the loaded image shape.")
+
+        self._projection_mask_display_volume = build_oriented_volume(
+            mask_volume.data,
+            mask_volume.affine,
+        )
+        self._update_projection_overrides()
 
     def set_annotation_overlay(
         self,
@@ -833,6 +858,11 @@ class TriPlanarViewerWidget(QWidget):
                 volume,
                 view.orientation,
                 self._projection_mode,
+                mask=(
+                    None
+                    if self._projection_mask_display_volume is None
+                    else self._projection_mask_display_volume.display_data
+                ),
             )
             segmentation_projection_slice = None
             if self._segmentation_display_volume is not None:

--- a/src/mipview/viewer/triplanar_viewer_widget.py
+++ b/src/mipview/viewer/triplanar_viewer_widget.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import logging
 import os
 from pathlib import Path
@@ -12,6 +13,11 @@ from mipview.annotation.annotation_mask import AnnotationMask
 from mipview.annotation.brush import erase_disk, paint_disk
 from mipview.annotation.undo import AnnotationUndoStack
 from mipview.graph.state import ProjectionGraphState
+from mipview.graph.model import ProjectionGraphLayer, VoxelPoint
+from mipview.graph.spatial import (
+    resolve_projection_voxel,
+    update_control_point_from_projection,
+)
 from mipview.ui.drop_loading import first_supported_local_nifti_path
 from mipview.state.cursor_state import CursorState
 from mipview.state.zoom_state import ZoomState
@@ -94,6 +100,8 @@ class TriPlanarViewerWidget(QWidget):
         self.zoom_state = ZoomState(self, maximum_zoom=maximum_zoom)
         self.patch_selector = PatchSelector(DEFAULT_PATCH_SIZE)
         self._projection_mode = "MIP"
+        self._projection_segmentation_enabled = True
+        self._projection_segmentation_source: str | None = "all"
         self._active_view: Orientation | None = None
         self._drop_loading_enabled = False
         self._projection_enabled: dict[str, bool] = {
@@ -369,6 +377,23 @@ class TriPlanarViewerWidget(QWidget):
     def projection_mode(self) -> str:
         return self._projection_mode
 
+    def set_projection_segmentation_enabled(self, enabled: bool) -> None:
+        normalized = bool(enabled)
+        if self._projection_segmentation_enabled == normalized:
+            return
+        self._projection_segmentation_enabled = normalized
+        self._update_projection_overrides()
+
+    def set_projection_segmentation_source(self, source: str | None) -> None:
+        if source not in {None, "file", "annotation", "all"}:
+            raise ValueError(
+                "Projection segmentation source must be file, annotation, all, or None."
+            )
+        if self._projection_segmentation_source == source:
+            return
+        self._projection_segmentation_source = source
+        self._update_projection_overrides()
+
     def projection_enabled(self, orientation: Orientation) -> bool:
         return bool(self._projection_enabled.get(orientation, False))
 
@@ -393,7 +418,7 @@ class TriPlanarViewerWidget(QWidget):
     def refresh_graph_overlay(self) -> None:
         graph_state = self._projection_graph_state
         for view in self._views:
-            if graph_state is None:
+            if graph_state is None or self._display_volume is None:
                 view.set_graph_overlay(
                     None,
                     editing_enabled=False,
@@ -408,13 +433,16 @@ class TriPlanarViewerWidget(QWidget):
                     angle_vectors=(),
                 )
                 continue
-            pending_node_id = (
-                graph_state.pending_edge_node_id
-                if graph_state.pending_edge_orientation == view.orientation
-                else None
+            layer = graph_state.projected_layer(
+                view.orientation,
+                self._display_volume,
+            )
+            layer = replace(
+                layer,
+                node_hit_priorities=self._graph_node_hit_priorities(layer),
             )
             view.set_graph_overlay(
-                graph_state.layer(view.orientation),
+                layer,
                 editing_enabled=(
                     graph_state.editing_enabled
                     and self.projection_enabled(view.orientation)
@@ -423,13 +451,9 @@ class TriPlanarViewerWidget(QWidget):
                 opacity=graph_state.opacity,
                 node_size=graph_state.node_size,
                 edge_thickness=graph_state.edge_thickness,
-                pending_node_id=pending_node_id,
+                pending_node_id=graph_state.pending_edge_node_id,
                 active_tool=graph_state.active_tool,
-                selected_edge=(
-                    graph_state.selected_edge
-                    if graph_state.selected_edge_orientation == view.orientation
-                    else None
-                ),
+                selected_edge=graph_state.selected_edge,
                 curve_handle_visible=graph_state.selected_edge is not None,
                 angle_vectors=tuple(
                     vector
@@ -441,6 +465,62 @@ class TriPlanarViewerWidget(QWidget):
                     if vector is not None and vector.orientation == view.orientation
                 ),
             )
+
+    def graph_projected_layer(
+        self,
+        orientation: Orientation,
+    ) -> ProjectionGraphLayer:
+        if self._projection_graph_state is None or self._display_volume is None:
+            raise ValueError("Graph projection geometry is not available.")
+        return self._projection_graph_state.projected_layer(
+            orientation,
+            self._display_volume,
+        )
+
+    def resolve_graph_projection_voxel(
+        self,
+        orientation: Orientation,
+        horizontal_index: int,
+        vertical_index: int,
+    ) -> tuple[int, int, int]:
+        if self._display_volume is None:
+            raise ValueError("Graph projection geometry is not available.")
+        source_cursor = self.cursor_state.cursor_position()
+        preferred_display = (
+            None
+            if source_cursor is None
+            else self._display_volume.source_to_display(source_cursor)
+        )
+        return resolve_projection_voxel(
+            self._display_volume,
+            orientation,
+            self._projection_mode,
+            horizontal_index,
+            vertical_index,
+            mask_display_data=(
+                None
+                if self._projection_mask_display_volume is None
+                else self._projection_mask_display_volume.display_data
+            ),
+            preferred_display_voxel=preferred_display,
+        )
+
+    def graph_control_point_from_projection(
+        self,
+        source_control_point: VoxelPoint,
+        orientation: Orientation,
+        horizontal: float,
+        vertical: float,
+    ) -> VoxelPoint:
+        if self._display_volume is None:
+            raise ValueError("Graph projection geometry is not available.")
+        return update_control_point_from_projection(
+            source_control_point,
+            self._display_volume,
+            orientation,
+            horizontal,
+            vertical,
+        )
 
     def set_drop_loading_enabled(self, enabled: bool) -> None:
         self._drop_loading_enabled = enabled
@@ -714,21 +794,34 @@ class TriPlanarViewerWidget(QWidget):
     def _sync_graph_plane_shapes(self) -> None:
         if self._display_volume is None or self._projection_graph_state is None:
             return
-        cleared_orientations: list[Orientation] = []
-        for orientation in ("axial", "coronal", "sagittal"):
-            plane_shape = plane_shape_for_orientation(
-                self._display_volume.display_shape,
-                orientation,
+        if self._projection_graph_state.set_volume_geometry(
+            self._display_volume.source_shape,
+            self._display_volume.source_to_display_affine,
+        ):
+            self.graph_layers_cleared.emit(("axial", "coronal", "sagittal"))
+
+    def _graph_node_hit_priorities(
+        self,
+        layer: ProjectionGraphLayer,
+    ) -> dict[int, int]:
+        if self._projection_graph_state is None:
+            return {}
+        priorities: dict[int, int] = {}
+        for node_id, projected_node in layer.nodes.items():
+            try:
+                extremum_voxel = self.resolve_graph_projection_voxel(
+                    layer.orientation,
+                    int(round(projected_node.horizontal_index)),
+                    int(round(projected_node.vertical_index)),
+                )
+            except ValueError:
+                priorities[node_id] = 1
+                continue
+            priorities[node_id] = int(
+                self._projection_graph_state.graph.nodes[node_id].position()
+                != extremum_voxel
             )
-            if self._projection_graph_state.layer(orientation).set_plane_shape(
-                plane_shape
-            ):
-                cleared_orientations.append(orientation)
-        if cleared_orientations:
-            self._projection_graph_state.invalidate_orientations(
-                tuple(cleared_orientations)
-            )
-            self.graph_layers_cleared.emit(tuple(cleared_orientations))
+        return priorities
 
     def _update_shared_base_scale(self) -> None:
         if self._display_volume is None:
@@ -865,14 +958,26 @@ class TriPlanarViewerWidget(QWidget):
                 ),
             )
             segmentation_projection_slice = None
-            if self._segmentation_display_volume is not None:
+            if (
+                self._projection_segmentation_enabled
+                and self._projection_segmentation_source in {"file", "all"}
+                and self._segmentation_display_volume is not None
+            ):
                 segmentation_projection_slice = project_oriented_volume(
                     self._segmentation_display_volume.display_data,
                     view.orientation,
-                    self._projection_mode,
+                    (
+                        self._projection_mode
+                        if self._projection_segmentation_source == "all"
+                        else "MIP"
+                    ),
                 )
             annotation_projection_slice = None
-            if self._annotation_display_volume is not None:
+            if (
+                self._projection_segmentation_enabled
+                and self._projection_segmentation_source in {"annotation", "all"}
+                and self._annotation_display_volume is not None
+            ):
                 annotation_projection_slice = project_oriented_volume(
                     self._annotation_display_volume.display_data,
                     view.orientation,

--- a/src/mipview/viewer/triplanar_viewer_widget.py
+++ b/src/mipview/viewer/triplanar_viewer_widget.py
@@ -431,6 +431,10 @@ class TriPlanarViewerWidget(QWidget):
                     selected_edge=None,
                     curve_handle_visible=False,
                     angle_vectors=(),
+                    normal_line_edge=None,
+                    normal_line_thickness=1,
+                    extension_line_edge=None,
+                    extension_line_thickness=1,
                 )
                 continue
             layer = graph_state.projected_layer(
@@ -464,6 +468,18 @@ class TriPlanarViewerWidget(QWidget):
                     )
                     if vector is not None and vector.orientation == view.orientation
                 ),
+                normal_line_edge=(
+                    graph_state.normal_line_edge
+                    if graph_state.normal_line_orientation == view.orientation
+                    else None
+                ),
+                normal_line_thickness=graph_state.normal_line_thickness,
+                extension_line_edge=(
+                    graph_state.extension_line_edge
+                    if graph_state.extension_line_orientation == view.orientation
+                    else None
+                ),
+                extension_line_thickness=graph_state.extension_line_thickness,
             )
 
     def graph_projected_layer(


### PR DESCRIPTION
Summary

- v0.5.2 improves projection viewing, graph editing, and segmentation visualization:
- Added optional segmentation-mask-aware MIP/MinIP calculations.
- Added MIP overlays for active segmentation and annotation layers.
- Added deterministic multi-label segmentation colors.
- Reworked projection graphs into one shared 3D voxel-space graph displayed across axial, coronal, and sagittal views.
- Added cross-view graph editing, explicit voxel-node creation, and richer coordinate reporting.
- Added normal and extension construction lines for straight graph edges.
- Added a View tab to patch windows and accessible overlay-opacity controls in main and patch windows.
- Expanded the CLI and control layer for the new graph operations.
- Improved handling of non-finite image intensities.
- Updated documentation and bumped the package version from 0.5.1 to 0.5.2.
