### PR TITLE
V0.5.6:Update dependencies for 3D rendering support with VisPy and PyOpenGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ pip install -r requirements.txt
 
 This `requirements.txt` mirrors the runtime dependencies used by the app and is intended for Docker-style installs. In installed/container environments, the intended launch command remains `mipview`.
 
+The optional 3D viewer uses VisPy with its PySide6 backend and PyOpenGL for
+raw-volume texture uploads. A working OpenGL implementation is also required.
+If 3D rendering is unavailable, the orthogonal viewers remain usable and the
+**3D Volume** toolbox reports an actionable error.
+Camera framing uses affine-scaled world bounds so raw textures and foreground
+meshes open at the same physical scale and default viewing angle.
+
 CI note:
 
 - GitHub Actions validates three install paths (`setup.sh`, `pip install -e .`, and `pip install -r requirements.txt`) and runs a headless startup smoke test for each.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mipview"
-version = "0.5.5"
+version = "0.5.6"
 description = "A lightweight Linux-first NIfTI viewer for patch-based inspection workflows."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -17,7 +17,8 @@ dependencies = [
   "nibabel>=5.2",
   "numpy>=1.26",
   "scikit-image>=0.23",
-  "vispy>=0.16"
+  "vispy>=0.16",
+  "PyOpenGL>=3.1.7"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nibabel>=5.2
 numpy>=1.26
 scikit-image>=0.23
 vispy>=0.16
+PyOpenGL>=3.1.7

--- a/src/mipview/viewer/volume_3d_widget.py
+++ b/src/mipview/viewer/volume_3d_widget.py
@@ -338,8 +338,55 @@ class Volume3DWidget(QWidget):
 
     def reset_camera(self) -> None:
         if self._view is not None:
-            self._view.camera.set_range()
+            camera = self._view.camera
+            camera.azimuth = 30.0
+            camera.elevation = 30.0
+            camera.roll = 0.0
+            limits = self._camera_world_limits()
+            if limits is None:
+                camera.set_range()
+            else:
+                camera.set_range(
+                    x=limits[0],
+                    y=limits[1],
+                    z=limits[2],
+                    margin=0.08,
+                )
             self._request_canvas_update()
+
+    def _camera_world_limits(
+        self,
+    ) -> tuple[
+        tuple[float, float],
+        tuple[float, float],
+        tuple[float, float],
+    ] | None:
+        if self._locator_visible:
+            if self._locator_volume is not None:
+                return _volume_world_limits(
+                    tuple(int(value) for value in self._locator_volume.shape),
+                    self._locator_volume.affine,
+                )
+            if (
+                self._locator_source_shape is not None
+                and self._locator_source_affine is not None
+            ):
+                return _volume_world_limits(
+                    self._locator_source_shape,
+                    self._locator_source_affine,
+                )
+
+        prepared = self._prepared
+        if prepared is None:
+            return None
+        if prepared.texture_affine is not None:
+            return _volume_world_limits(
+                prepared.prepared_shape,
+                prepared.texture_affine,
+            )
+        if prepared.vertices is not None and prepared.vertices.size:
+            return _point_world_limits(prepared.vertices)
+        return None
 
     def set_patch_box(
         self,
@@ -509,6 +556,7 @@ class Volume3DWidget(QWidget):
 
         rgba = _rgba(settings.colour, settings.opacity)
         if prepared.kind == "image":
+            _require_pyopengl_3d_textures()
             method = {
                 "MIP": "mip",
                 "MinIP": "minip",
@@ -729,6 +777,45 @@ def _rgba(
         colour[2] / 255.0,
         min(max(float(opacity), 0.0), 1.0),
     )
+
+
+def _volume_world_limits(
+    shape: tuple[int, int, int],
+    affine: np.ndarray,
+) -> tuple[
+    tuple[float, float],
+    tuple[float, float],
+    tuple[float, float],
+]:
+    return _point_world_limits(source_box_world_segments(shape, affine))
+
+
+def _point_world_limits(
+    points: np.ndarray,
+) -> tuple[
+    tuple[float, float],
+    tuple[float, float],
+    tuple[float, float],
+]:
+    coordinates = np.asarray(points, dtype=np.float64).reshape(-1, 3)
+    minimum = np.min(coordinates, axis=0)
+    maximum = np.max(coordinates, axis=0)
+    return tuple(
+        (float(minimum[axis]), float(maximum[axis]))
+        for axis in range(3)
+    )
+
+
+def _require_pyopengl_3d_textures() -> None:
+    """Fail before VisPy's deferred draw when 3D texture support is absent."""
+    try:
+        import OpenGL.GL  # noqa: F401
+    except ImportError as exc:
+        raise RuntimeError(
+            "PyOpenGL is required for raw-image 3D rendering. "
+            "Reinstall MipView dependencies or run "
+            "`python -m pip install PyOpenGL` in the active environment."
+        ) from exc
 
 
 def _volume_colormap(


### PR DESCRIPTION
**3D Viewer Improvements:**

* The camera in `Volume3DWidget` is now automatically framed to affine-scaled world bounds, ensuring that both raw textures and foreground meshes open at the correct physical scale and default viewing angle. This is handled by the new `_camera_world_limits` method and updated logic in `reset_camera`.
* Utility functions `_volume_world_limits` and `_point_world_limits` are added to calculate world-space bounds for camera framing.

**Dependency and Error Handling:**

* The code now explicitly checks for `PyOpenGL` before attempting raw 3D texture rendering, raising a clear error if it is missing. This avoids deferred runtime failures during 3D rendering. [[1]](diffhunk://#diff-c78275fc364733352535563859202bd1ca79a8742d7f25ddf8116c299a2a9df2R559) [[2]](diffhunk://#diff-c78275fc364733352535563859202bd1ca79a8742d7f25ddf8116c299a2a9df2R782-R820)
* `PyOpenGL>=3.1.7` is added to the main dependencies in `pyproject.toml` to ensure required 3D rendering support.

**Versioning:**

* The project version is bumped from `0.5.5` to `0.5.6` to reflect these enhancements.