### PR TITLE
V0.5.7: Add orientation indicator and mask-aware MIP support in 3D rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ It is designed as a focused research tool for:
 - projection-graph editing with local state save/load, drag-and-drop patch restoration,
   persistent directed vectors, straight or curved edges, restored MIP/MinIP
   orientation settings, and physical-spacing-aware one-to-one angle measurements,
+- import-only GraphML vessel skeletons as read-only 3D file layers, with
+  patch-clipped MIP/MinIP projections, red source nodes, green edges, and blue
+  synthetic patch-boundary intersections,
 - patch-window 2×2 viewer screenshot export at 1–200% output resolution,
 - independent patch-window translation along LR, AP, and SI with live projection
   and aligned-overlay refresh,
@@ -147,6 +150,10 @@ The current codebase is organized around a small top-level `mipview` package:
     │   ├── spatial.py
     │   ├── state.py
     │   └── vector.py
+    ├── vessel_graph/
+    │   ├── io.py
+    │   ├── model.py
+    │   └── spatial.py
     ├── io/
     │   └── nifti_io.py
     ├── patch/
@@ -171,6 +178,8 @@ In practice, the main runtime flow is:
 4. `viewer/` modules render slices, projections, and the optional VisPy 3D
    scene, and manage tri-planar, zoom, pan, annotation, graph, and patch-locator
    interactions.
-5. `graph/` keeps graph identity, curve geometry, persistent vectors, measurement calculations, and interaction state outside the Qt panel code.
+5. `graph/` owns editable 2D MIP/MinIP `.mipgraph.json` state;
+   `vessel_graph/` independently owns import-only 3D `.graphml` data, spatial
+   validation, patch clipping, and projections.
 6. `control/` exposes structured local IPC commands through the command registry, controller, and `mipview-ctl` CLI.
 7. `state/`, `io/`, `patch/`, `segmentation/`, `annotation/`, and `tools/` provide the remaining supporting logic.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mipview"
-version = "0.5.6"
+version = "0.5.7"
 description = "A lightweight Linux-first NIfTI viewer for patch-based inspection workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mipview/control/README.md
+++ b/src/mipview/control/README.md
@@ -26,6 +26,7 @@ Most state-changing commands require a NIfTI image to already be loaded in the r
 - [`patch.screenshot`](#patchscreenshot)
 - [`projection.mode`](#projectionmode)
 - [`projection.save`](#projectionsave)
+- [`graph3d.*`](#graphml-vessel-graph-commands)
 - [`graph.*`](#graph-commands)
 - [`annotation.create`](#annotationcreate)
 - [`annotation.paint_stroke`](#annotationpaint_stroke)
@@ -501,6 +502,41 @@ The equivalent direct commands are `render3d.status`, `render3d.activate`,
 `render3d.select`, `render3d.update`, `render3d.set_display`,
 `render3d.reset_camera`, and `patch.display_location`.
 
+### GraphML vessel-graph commands
+
+The `graph3d.*` namespace controls import-only GraphML vessel graphs and is
+separate from the editable `graph.*` JSON projection-graph namespace. A source
+NIfTI must be loaded before `graph3d load`. Loading is main-session scoped and
+new and existing patch windows receive the layer list.
+
+```bash
+mipview-ctl graph3d load ./vessels.graphml
+mipview-ctl graph3d status
+mipview-ctl graph3d select LAYER_ID
+mipview-ctl graph3d display LAYER_ID --visible --opacity 0.65
+mipview-ctl graph3d status --session-id SESSION_ID
+mipview-ctl graph3d select LAYER_ID --session-id SESSION_ID
+mipview-ctl graph3d display LAYER_ID --session-id SESSION_ID --visible
+mipview-ctl graph3d unload LAYER_ID
+```
+
+`graph3d display` also accepts `--node-size` and `--edge-thickness`. For a patch
+session, `--visible` controls GraphML projection and `--opacity` controls the
+shared 2D created/projected graph opacity. Node size and edge thickness are
+shared by those 2D layers and the patch's GraphML 3D source. Use
+`render3d display --session-id SESSION_ID --opacity VALUE` for 3D-only opacity.
+Only one GraphML projection layer is visible in a patch at a time. Enabling it
+exits graph creation and hides the editable JSON graph without deleting either
+layer. Disabling it does not automatically restore the created graph. The
+matching direct commands are `graph3d.status`, `graph3d.load`,
+`graph3d.unload`, `graph3d.select`, and `graph3d.set_display`.
+
+GraphML is read-only. Red markers are original nodes, green lines are vessel
+edges, and blue markers are synthetic patch-boundary intersections. The `r`
+attribute is reported as retained analytical metadata but does not affect
+rendering. Spatially mismatched files remain loaded in warning mode, with patch
+projection disabled.
+
 ### Graph commands
 
 Graph commands target an open patch window by the session ID reported in
@@ -508,8 +544,9 @@ Graph commands target an open patch window by the session ID reported in
 three projections and stored in patch-local source voxel space. `add-node` uses
 oriented 2D projection indices and resolves depth from the current finite
 MIP/MinIP extremum; `add-voxel-node` accepts explicit patch-local `(x, y, z)`
-coordinates. Node/edge editing commands require Graph mode; clearing the complete
-graph remains available whenever the session contains graph elements.
+coordinates. Node/edge editing commands require graph creation to be enabled;
+disabling creation leaves the created graph visible and read-only. Clearing the
+complete graph remains available whenever the session contains graph elements.
 
 ```bash
 mipview-ctl graph status SESSION_ID

--- a/src/mipview/control/README.md
+++ b/src/mipview/control/README.md
@@ -477,7 +477,7 @@ and `render3d update` starts background preparation.
 mipview-ctl render3d status
 mipview-ctl render3d activate
 mipview-ctl render3d select image
-mipview-ctl render3d display --opacity 0.6 --mode MIP
+mipview-ctl render3d display --opacity 0.6 --mode MIP --mask SEGMENTATION_ID
 mipview-ctl render3d update
 mipview-ctl render3d reset-camera
 mipview-ctl render3d dismiss
@@ -487,11 +487,15 @@ mipview-ctl patch display-location SESSION_ID show
 ```
 
 `render3d display` accepts `--visible` / `--no-visible`, `--opacity`,
-`--colour R G B`, `--mode`, and `--threshold`. Exactly one selected NIfTI file
-is rendered at a time. Dismissing the view releases its VisPy canvas and GPU
-resources. `render3d.status` reports the selected and rendered source IDs,
-busy/update-required state, prepared shape, downsampling stride, locator state,
-and the last renderer error.
+`--colour R G B`, `--mode`, `--mask`, `--no-mask`, and `--threshold`. Masks
+include all nonzero voxels and must be loaded,
+spatially compatible segmentation layers. Masking applies to image MIP/MinIP
+and segmentation Surface/Points modes; it is ignored for image Translucent and
+Isosurface modes. Exactly one selected NIfTI file is rendered at a time.
+Dismissing the view releases its VisPy canvas and GPU resources.
+`render3d.status` reports the selected and rendered source IDs, selected mask,
+whether that mask applies to the current mode, busy/update-required state,
+prepared shape, downsampling stride, locator state, and the last renderer error.
 
 The equivalent direct commands are `render3d.status`, `render3d.activate`,
 `render3d.select`, `render3d.update`, `render3d.set_display`,

--- a/src/mipview/control/cli.py
+++ b/src/mipview/control/cli.py
@@ -269,6 +269,19 @@ def _build_parser() -> argparse.ArgumentParser:
     render_display.add_argument("--opacity", type=float, default=None)
     render_display.add_argument("--colour", type=int, nargs=3, default=None)
     render_display.add_argument("--mode", default=None)
+    render_mask_group = render_display.add_mutually_exclusive_group()
+    render_mask_group.add_argument(
+        "--mask",
+        default=None,
+        help="Segmentation source ID to use as a mask.",
+    )
+    render_mask_group.add_argument(
+        "--no-mask",
+        dest="mask",
+        action="store_const",
+        const="---",
+        help="Clear the selected 3D render mask.",
+    )
     render_display.add_argument("--threshold", type=float, default=None)
 
     projection_parser = subparsers.add_parser(
@@ -688,16 +701,19 @@ def _command_from_args(args: argparse.Namespace) -> tuple[str, dict[str, Any], A
         if args.render3d_command == "reset-camera":
             return "render3d.reset_camera", common, None
         if args.render3d_command == "display":
+            display_args = {
+                **common,
+                "visible": args.visible,
+                "opacity": args.opacity,
+                "colour": args.colour,
+                "render_mode": args.mode,
+                "threshold": args.threshold,
+            }
+            if args.mask is not None:
+                display_args["mask_source_id"] = args.mask
             return (
                 "render3d.set_display",
-                {
-                    **common,
-                    "visible": args.visible,
-                    "opacity": args.opacity,
-                    "colour": args.colour,
-                    "render_mode": args.mode,
-                    "threshold": args.threshold,
-                },
+                display_args,
                 None,
             )
 

--- a/src/mipview/control/cli.py
+++ b/src/mipview/control/cli.py
@@ -284,6 +284,40 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     render_display.add_argument("--threshold", type=float, default=None)
 
+    graph3d_parser = subparsers.add_parser(
+        "graph3d",
+        help="Load and display read-only 3D GraphML vessel graphs.",
+        description=(
+            "GraphML commands are separate from the editable patch projection-graph "
+            "commands. Omit --session-id for main-window settings."
+        ),
+        formatter_class=_HelpFormatter,
+    )
+    graph3d_subparsers = graph3d_parser.add_subparsers(
+        dest="graph3d_command",
+        required=True,
+    )
+    graph3d_status = graph3d_subparsers.add_parser("status")
+    graph3d_status.add_argument("--session-id", default=None)
+    graph3d_load = graph3d_subparsers.add_parser("load")
+    graph3d_load.add_argument("path", metavar="GRAPHML_PATH")
+    graph3d_unload = graph3d_subparsers.add_parser("unload")
+    graph3d_unload.add_argument("layer_id", metavar="LAYER_ID")
+    graph3d_select = graph3d_subparsers.add_parser("select")
+    graph3d_select.add_argument("layer_id", metavar="LAYER_ID")
+    graph3d_select.add_argument("--session-id", default=None)
+    graph3d_display = graph3d_subparsers.add_parser("display")
+    graph3d_display.add_argument("layer_id", metavar="LAYER_ID")
+    graph3d_display.add_argument("--session-id", default=None)
+    graph3d_display.add_argument(
+        "--visible",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+    )
+    graph3d_display.add_argument("--opacity", type=float, default=None)
+    graph3d_display.add_argument("--node-size", type=int, default=None)
+    graph3d_display.add_argument("--edge-thickness", type=int, default=None)
+
     projection_parser = subparsers.add_parser(
         "projection",
         help="Set MIP/MinIP mode and save patch projections.",
@@ -368,9 +402,15 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Replace an existing non-empty graph.",
     )
-    graph_activate = graph_subparsers.add_parser("activate", help="Activate Graph mode.")
+    graph_activate = graph_subparsers.add_parser(
+        "activate",
+        help="Enable creating the 2D graph.",
+    )
     graph_activate.add_argument("session_id", metavar="SESSION_ID")
-    graph_exit = graph_subparsers.add_parser("exit", help="Exit Graph mode.")
+    graph_exit = graph_subparsers.add_parser(
+        "exit",
+        help="Disable creation while leaving the created graph visible.",
+    )
     graph_exit.add_argument("session_id", metavar="SESSION_ID")
     graph_display = graph_subparsers.add_parser(
         "display",
@@ -714,6 +754,40 @@ def _command_from_args(args: argparse.Namespace) -> tuple[str, dict[str, Any], A
             return (
                 "render3d.set_display",
                 display_args,
+                None,
+            )
+
+    if args.group == "graph3d":
+        if args.graph3d_command == "status":
+            return (
+                "graph3d.status",
+                {"session_id": args.session_id},
+                None,
+            )
+        if args.graph3d_command == "load":
+            return "graph3d.load", {"path": args.path}, None
+        if args.graph3d_command == "unload":
+            return "graph3d.unload", {"layer_id": args.layer_id}, None
+        if args.graph3d_command == "select":
+            return (
+                "graph3d.select",
+                {
+                    "layer_id": args.layer_id,
+                    "session_id": args.session_id,
+                },
+                None,
+            )
+        if args.graph3d_command == "display":
+            return (
+                "graph3d.set_display",
+                {
+                    "layer_id": args.layer_id,
+                    "session_id": args.session_id,
+                    "visible": args.visible,
+                    "opacity": args.opacity,
+                    "node_size": args.node_size,
+                    "edge_thickness": args.edge_thickness,
+                },
                 None,
             )
 

--- a/src/mipview/control/command_registry.py
+++ b/src/mipview/control/command_registry.py
@@ -51,6 +51,14 @@ class CommandRegistry:
         self.register("render3d.update", self.controller.update_render3d)
         self.register("render3d.set_display", self.controller.set_render3d_display)
         self.register("render3d.reset_camera", self.controller.reset_render3d_camera)
+        self.register("graph3d.status", self.controller.get_vessel_graph_status)
+        self.register("graph3d.load", self.controller.load_vessel_graph)
+        self.register("graph3d.unload", self.controller.unload_vessel_graph)
+        self.register("graph3d.select", self.controller.select_vessel_graph)
+        self.register(
+            "graph3d.set_display",
+            self.controller.set_vessel_graph_display,
+        )
         self.register(
             "patch.display_location",
             self.controller.set_patch_location_display,

--- a/src/mipview/control/controller.py
+++ b/src/mipview/control/controller.py
@@ -31,6 +31,7 @@ from mipview.viewer.slice_geometry import project_oriented_volume
 
 SUPPORTED_ORIENTATIONS: set[str] = {"axial", "coronal", "sagittal"}
 SUPPORTED_PROJECTION_MODES: set[str] = {"MIP", "MINIP"}
+_UNSET = object()
 
 
 class MipViewController:
@@ -186,6 +187,7 @@ class MipViewController:
         colour: list[int] | tuple[int, int, int] | None = None,
         render_mode: str | None = None,
         threshold: float | None = None,
+        mask_source_id: object = _UNSET,
     ) -> CommandResult:
         target = self._render3d_target(session_id)
         if isinstance(target, CommandResult):
@@ -210,6 +212,33 @@ class MipViewController:
                     False,
                     f"3D render mode must be one of: {', '.join(allowed_modes)}.",
                 )
+        normalized_mask_id: str | None = None
+        if mask_source_id is not _UNSET:
+            if mask_source_id is not None and not isinstance(mask_source_id, str):
+                return CommandResult(
+                    False,
+                    "3D render mask source ID must be a string or null.",
+                )
+            normalized_mask_id = (
+                None
+                if mask_source_id in {None, "---"}
+                else str(mask_source_id)
+            )
+            compatible_ids = {
+                source.id
+                for source in target.state.compatible_masks_for(
+                    target.state.selected_source_id
+                )
+            }
+            if (
+                normalized_mask_id is not None
+                and normalized_mask_id not in compatible_ids
+            ):
+                return CommandResult(
+                    False,
+                    "3D render mask must be a loaded, spatially compatible "
+                    f"segmentation layer: {normalized_mask_id}",
+                )
         if visible is not None:
             target.set_selected_visibility(visible)
         if opacity is not None:
@@ -220,6 +249,8 @@ class MipViewController:
             target.set_selected_render_mode(str(render_mode))
         if threshold is not None:
             target.set_selected_threshold(float(threshold))
+        if mask_source_id is not _UNSET:
+            target.set_selected_mask_source(normalized_mask_id)
         return CommandResult(True, "3D display settings updated.", target.status())
 
     def reset_render3d_camera(

--- a/src/mipview/control/controller.py
+++ b/src/mipview/control/controller.py
@@ -24,6 +24,7 @@ from mipview.viewer.oriented_volume import build_oriented_volume
 from mipview.viewer.render_3d_state import (
     RAW_RENDER_MODES,
     SEGMENTATION_RENDER_MODES,
+    VESSEL_GRAPH_RENDER_MODES,
 )
 from mipview.viewer.slice_geometry import Orientation
 from mipview.viewer.slice_geometry import project_oriented_volume
@@ -58,6 +59,7 @@ class MipViewController:
                 "annotation_editing_enabled": bool(state.annotation.editing_enabled),
                 "num_segmentations": len(state.loaded_segmentations),
                 "num_graph_sessions": len(self.main_window.graph_session_summaries()),
+                "num_graphml_layers": len(state.loaded_vessel_graphs),
                 "orientation_indicator_mode": (
                     self.main_window.slice_viewer.orientation_indicator_mode()
                 ),
@@ -111,6 +113,7 @@ class MipViewController:
                 "brush_mode": annotation.brush_mode,
             },
             "graph_sessions": self.main_window.graph_session_summaries(),
+            "vessel_graphs": self.main_window.vessel_graph_status(),
             "render3d": slice_viewer.volume_3d_view.status(),
         }
         if volume is not None:
@@ -205,7 +208,11 @@ class MipViewController:
             allowed_modes = (
                 RAW_RENDER_MODES
                 if source is not None and source.kind == "image"
-                else SEGMENTATION_RENDER_MODES
+                else (
+                    SEGMENTATION_RENDER_MODES
+                    if source is not None and source.kind == "segmentation"
+                    else VESSEL_GRAPH_RENDER_MODES
+                )
             )
             if render_mode not in allowed_modes:
                 return CommandResult(
@@ -264,6 +271,149 @@ class MipViewController:
             return CommandResult(False, "Activate the 3D view before resetting its camera.")
         target.reset_camera()
         return CommandResult(True, "3D camera reset.", target.status())
+
+    def get_vessel_graph_status(
+        self,
+        session_id: str | None = None,
+    ) -> CommandResult:
+        if session_id is None:
+            return CommandResult(
+                True,
+                "GraphML layer status exported.",
+                self.main_window.vessel_graph_status(),
+            )
+        patch_window = self._graph_patch_window(session_id)
+        if patch_window is None:
+            return CommandResult(False, f"Patch window not found: {session_id}")
+        return CommandResult(
+            True,
+            "Patch GraphML layer status exported.",
+            patch_window.vessel_graph_status(),
+        )
+
+    def load_vessel_graph(self, path: str) -> CommandResult:
+        try:
+            layer, already_loaded = self.main_window.load_vessel_graph(Path(path))
+        except (FileNotFoundError, OSError, ValueError) as exc:
+            return CommandResult(False, str(exc))
+        return CommandResult(
+            True,
+            (
+                "GraphML layer already loaded."
+                if already_loaded
+                else "GraphML layer loaded."
+            ),
+            layer.status(),
+        )
+
+    def unload_vessel_graph(self, layer_id: str) -> CommandResult:
+        try:
+            removed = self.main_window.unload_vessel_graph(str(layer_id))
+        except ValueError as exc:
+            return CommandResult(False, str(exc))
+        return CommandResult(
+            True,
+            "GraphML layer unloaded.",
+            removed.status(),
+        )
+
+    def select_vessel_graph(
+        self,
+        layer_id: str,
+        session_id: str | None = None,
+    ) -> CommandResult:
+        normalized_id = str(layer_id)
+        if session_id is None:
+            if not any(
+                layer.id == normalized_id
+                for layer in self.main_window.state.loaded_vessel_graphs
+            ):
+                return CommandResult(
+                    False,
+                    f"GraphML layer does not exist: {normalized_id}",
+                )
+            self.main_window._on_vessel_graph_layer_changed(normalized_id)
+            return self.get_vessel_graph_status()
+        patch_window = self._graph_patch_window(session_id)
+        if patch_window is None:
+            return CommandResult(False, f"Patch window not found: {session_id}")
+        try:
+            patch_window.select_vessel_graph_layer(normalized_id)
+        except ValueError as exc:
+            return CommandResult(False, str(exc))
+        return CommandResult(
+            True,
+            "Patch GraphML layer selected.",
+            patch_window.vessel_graph_status(),
+        )
+
+    def set_vessel_graph_display(
+        self,
+        layer_id: str,
+        *,
+        session_id: str | None = None,
+        visible: bool | None = None,
+        opacity: float | None = None,
+        node_size: int | None = None,
+        edge_thickness: int | None = None,
+    ) -> CommandResult:
+        if opacity is not None and not 0.0 <= float(opacity) <= 1.0:
+            return CommandResult(False, "GraphML opacity must be between 0.0 and 1.0.")
+        if node_size is not None and not 1 <= int(node_size) <= 10:
+            return CommandResult(False, "GraphML node size must be between 1 and 10.")
+        if edge_thickness is not None and not 1 <= int(edge_thickness) <= 10:
+            return CommandResult(
+                False,
+                "GraphML edge thickness must be between 1 and 10.",
+            )
+        normalized_id = str(layer_id)
+        if session_id is not None:
+            patch_window = self._graph_patch_window(session_id)
+            if patch_window is None:
+                return CommandResult(False, f"Patch window not found: {session_id}")
+            try:
+                patch_window.set_vessel_graph_display(
+                    normalized_id,
+                    visible=visible,
+                    opacity=opacity,
+                    node_size=node_size,
+                    edge_thickness=edge_thickness,
+                )
+            except ValueError as exc:
+                return CommandResult(False, str(exc))
+            return CommandResult(
+                True,
+                "Patch GraphML display updated.",
+                patch_window.vessel_graph_status(),
+            )
+
+        layer = next(
+            (
+                candidate
+                for candidate in self.main_window.state.loaded_vessel_graphs
+                if candidate.id == normalized_id
+            ),
+            None,
+        )
+        if layer is None:
+            return CommandResult(
+                False,
+                f"GraphML layer does not exist: {normalized_id}",
+            )
+        if visible is not None:
+            layer.settings.visible = bool(visible)
+        if opacity is not None:
+            layer.settings.set_opacity(opacity)
+        if node_size is not None:
+            layer.settings.set_node_size(node_size)
+        if edge_thickness is not None:
+            layer.settings.set_edge_thickness(edge_thickness)
+        self.main_window._on_vessel_graph_layer_changed(layer.id)
+        return CommandResult(
+            True,
+            "GraphML display updated.",
+            layer.status(),
+        )
 
     def set_patch_location_display(
         self,
@@ -606,7 +756,11 @@ class MipViewController:
             return CommandResult(False, str(exc), {"session_id": session_id})
         return CommandResult(
             True,
-            "Graph mode activated." if enabled else "Graph mode exited.",
+            (
+                "Graph creation enabled."
+                if enabled
+                else "Graph creation disabled; created graph remains visible."
+            ),
             patch_window.graph_status(),
         )
 

--- a/src/mipview/control/controller.py
+++ b/src/mipview/control/controller.py
@@ -57,6 +57,9 @@ class MipViewController:
                 "annotation_editing_enabled": bool(state.annotation.editing_enabled),
                 "num_segmentations": len(state.loaded_segmentations),
                 "num_graph_sessions": len(self.main_window.graph_session_summaries()),
+                "orientation_indicator_mode": (
+                    self.main_window.slice_viewer.orientation_indicator_mode()
+                ),
                 "render3d": self.main_window.slice_viewer.volume_3d_view.status(),
             },
         )
@@ -83,6 +86,9 @@ class MipViewController:
                 "selection_enabled": bool(slice_viewer.patch_selection_enabled()),
             },
             "projection_mode": _projection_mode(slice_viewer),
+            "orientation_indicator_mode": (
+                slice_viewer.orientation_indicator_mode()
+            ),
             "segmentation": (
                 None
                 if active_segmentation is None

--- a/src/mipview/io/nifti_io.py
+++ b/src/mipview/io/nifti_io.py
@@ -17,6 +17,10 @@ class NiftiLoadResult:
     header: nib.nifti1.Nifti1Header | nib.nifti2.Nifti2Header
     shape: tuple[int, ...]
     dtype: np.dtype
+    original_shape: tuple[int, ...] | None = None
+    original_affine: np.ndarray | None = None
+    original_axcodes: tuple[str | None, ...] | None = None
+    original_to_loaded_voxel_affine: np.ndarray | None = None
 
 
 def load_nifti(path: str | Path) -> NiftiLoadResult:
@@ -46,12 +50,14 @@ def load_nifti(path: str | Path) -> NiftiLoadResult:
     source_to_canonical = nib.orientations.ornt_transform(
         source_orientation, canonical_orientation
     )
+    canonical_to_source_voxel_affine = nib.orientations.inv_ornt_aff(
+        source_to_canonical,
+        source_data.shape[:3],
+    )
     data = np.asanyarray(
         nib.orientations.apply_orientation(source_data, source_to_canonical)
     )
-    affine = source_affine @ nib.orientations.inv_ornt_aff(
-        source_to_canonical, source_data.shape[:3]
-    )
+    affine = source_affine @ canonical_to_source_voxel_affine
     header = image.header.copy()
     header.set_data_shape(data.shape)
     _, qform_code = header.get_qform(coded=True)
@@ -67,4 +73,10 @@ def load_nifti(path: str | Path) -> NiftiLoadResult:
         header=header,
         shape=shape,
         dtype=dtype,
+        original_shape=tuple(int(value) for value in source_data.shape),
+        original_affine=source_affine.copy(),
+        original_axcodes=tuple(nib.aff2axcodes(source_affine)),
+        original_to_loaded_voxel_affine=np.linalg.inv(
+            canonical_to_source_voxel_affine
+        ),
     )

--- a/src/mipview/state/app_state.py
+++ b/src/mipview/state/app_state.py
@@ -8,6 +8,7 @@ from mipview.annotation import AnnotationState
 from mipview.io.nifti_io import NiftiLoadResult
 from mipview.patch.selector import PatchBounds
 from mipview.segmentation.models import LoadedSegmentation
+from mipview.vessel_graph.model import VesselGraphLayer
 
 
 @dataclass
@@ -21,4 +22,6 @@ class AppState:
     loaded_segmentations: list[LoadedSegmentation] = field(default_factory=list)
     active_segmentation_id: str | None = None
     segmentation_opacity: float = 0.5
+    loaded_vessel_graphs: list[VesselGraphLayer] = field(default_factory=list)
+    active_vessel_graph_id: str | None = None
     annotation: AnnotationState = field(default_factory=AnnotationState)

--- a/src/mipview/tools/volume.py
+++ b/src/mipview/tools/volume.py
@@ -29,4 +29,16 @@ def derive_volume(source: NiftiLoadResult, data: np.ndarray) -> NiftiLoadResult:
         header=header,
         shape=tuple(int(dim) for dim in derived_data.shape),
         dtype=derived_data.dtype,
+        original_shape=source.original_shape,
+        original_affine=(
+            None
+            if source.original_affine is None
+            else np.asarray(source.original_affine).copy()
+        ),
+        original_axcodes=source.original_axcodes,
+        original_to_loaded_voxel_affine=(
+            None
+            if source.original_to_loaded_voxel_affine is None
+            else np.asarray(source.original_to_loaded_voxel_affine).copy()
+        ),
     )

--- a/src/mipview/ui/drop_load_choice_dialog.py
+++ b/src/mipview/ui/drop_load_choice_dialog.py
@@ -8,10 +8,18 @@ from PySide6.QtWidgets import QDialog, QPushButton, QVBoxLayout
 class DropLoadChoice(str, Enum):
     BASE_IMAGE = "base_image"
     SEGMENTATION = "segmentation"
+    GRAPH = "graph"
 
 
 class DropLoadChoiceDialog(QDialog):
-    def __init__(self, *, allow_segmentation: bool, parent=None) -> None:
+    def __init__(
+        self,
+        *,
+        allow_base_image: bool = True,
+        allow_segmentation: bool,
+        allow_graph: bool = False,
+        parent=None,
+    ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Load Dropped File")
         self.setModal(True)
@@ -22,6 +30,7 @@ class DropLoadChoiceDialog(QDialog):
         layout.setSpacing(8)
 
         self.base_image_button = QPushButton("Base Image", self)
+        self.base_image_button.setEnabled(allow_base_image)
         self.base_image_button.clicked.connect(
             lambda: self._finish_with_choice(DropLoadChoice.BASE_IMAGE)
         )
@@ -33,6 +42,13 @@ class DropLoadChoiceDialog(QDialog):
             lambda: self._finish_with_choice(DropLoadChoice.SEGMENTATION)
         )
         layout.addWidget(self.segmentation_button)
+
+        self.graph_button = QPushButton("Graph", self)
+        self.graph_button.setEnabled(allow_graph)
+        self.graph_button.clicked.connect(
+            lambda: self._finish_with_choice(DropLoadChoice.GRAPH)
+        )
+        layout.addWidget(self.graph_button)
 
     def selected_choice(self) -> DropLoadChoice | None:
         return self._selected_choice

--- a/src/mipview/ui/drop_loading.py
+++ b/src/mipview/ui/drop_loading.py
@@ -15,6 +15,10 @@ def is_supported_graph_state_path(path: str | Path) -> bool:
     return Path(path).name.lower().endswith(".mipgraph.json")
 
 
+def is_supported_graphml_path(path: str | Path) -> bool:
+    return Path(path).name.lower().endswith(".graphml")
+
+
 def first_supported_local_drop_path(urls: Iterable[QUrl]) -> Path | None:
     candidates = list(urls)
     if len(candidates) != 1:
@@ -26,6 +30,7 @@ def first_supported_local_drop_path(urls: Iterable[QUrl]) -> Path | None:
     if not (
         is_supported_nifti_path(candidate)
         or is_supported_graph_state_path(candidate)
+        or is_supported_graphml_path(candidate)
     ):
         return None
     return candidate

--- a/src/mipview/ui/graph_panel.py
+++ b/src/mipview/ui/graph_panel.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
-    QCheckBox,
+    QComboBox,
     QFormLayout,
     QHBoxLayout,
     QLabel,
@@ -19,7 +19,8 @@ from mipview.ui.collapsible_group_box import CollapsibleGroupBox
 
 class GraphPanel(QWidget):
     activation_requested = Signal()
-    visibility_changed = Signal(bool)
+    projection_layer_changed = Signal(object)
+    projection_toggle_requested = Signal()
     opacity_changed = Signal(float)
     node_size_changed = Signal(int)
     edge_thickness_changed = Signal(int)
@@ -52,17 +53,37 @@ class GraphPanel(QWidget):
         else:
             self.setFixedWidth(self.PANEL_WIDTH)
 
-        self.group = CollapsibleGroupBox("Graph", self)
+        self.group = CollapsibleGroupBox(
+            "2D Graph (only available on MIP/MinIP)",
+            self,
+        )
         form = QFormLayout(self.group)
         if adaptable_width:
             form.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
 
-        self.activation_button = QPushButton("Activate", self.group)
+        self.activation_button = QPushButton(
+            "Enable Creating Graph",
+            self.group,
+        )
         self.activation_button.clicked.connect(self.activation_requested.emit)
 
-        self.visible_checkbox = QCheckBox("Visible", self.group)
-        self.visible_checkbox.setChecked(True)
-        self.visible_checkbox.toggled.connect(self.visibility_changed.emit)
+        self.projected_graph_combo = QComboBox(self.group)
+        self.projected_graph_combo.addItem("---", None)
+        self.projected_graph_combo.currentIndexChanged.connect(
+            lambda _index: self.projection_layer_changed.emit(
+                self.projected_graph_combo.currentData()
+            )
+        )
+        self.projection_toggle_button = QPushButton(
+            "Enable Projecting 3D Graph",
+            self.group,
+        )
+        self.projection_toggle_button.clicked.connect(
+            self.projection_toggle_requested.emit
+        )
+        self.projection_status_label = QLabel("", self.group)
+        self.projection_status_label.setWordWrap(True)
+        self.projection_status_label.setVisible(False)
 
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal, self.group)
         self.opacity_slider.setRange(0, 100)
@@ -108,10 +129,16 @@ class GraphPanel(QWidget):
         )
         file_layout.setContentsMargins(0, 0, 0, 0)
         file_layout.setSpacing(6)
-        self.save_state_button = QPushButton("Save Graph State…", file_row)
+        self.save_state_button = QPushButton(
+            "Save Created Graph State…",
+            file_row,
+        )
         self.save_state_button.clicked.connect(self.save_state_requested.emit)
         file_layout.addWidget(self.save_state_button)
-        self.load_state_button = QPushButton("Load Graph State…", file_row)
+        self.load_state_button = QPushButton(
+            "Load Created Graph State…",
+            file_row,
+        )
         self.load_state_button.clicked.connect(self.load_state_requested.emit)
         file_layout.addWidget(self.load_state_button)
 
@@ -147,7 +174,9 @@ class GraphPanel(QWidget):
         )
 
         form.addRow(self.activation_button)
-        form.addRow(self.visible_checkbox)
+        form.addRow("3D Graph:", self.projected_graph_combo)
+        form.addRow(self.projection_toggle_button)
+        form.addRow(self.projection_status_label)
         form.addRow("Opacity:", self.opacity_slider)
         form.addRow("Node Size:", self.node_size_slider)
         form.addRow("Edge Thickness:", self.edge_thickness_slider)
@@ -179,7 +208,11 @@ class GraphPanel(QWidget):
         self.activation_button.setEnabled(bool(available))
 
     def set_editing_enabled(self, enabled: bool) -> None:
-        self.activation_button.setText("Exit" if enabled else "Activate")
+        self.activation_button.setText(
+            "Disable Creating Graph"
+            if enabled
+            else "Enable Creating Graph"
+        )
         self.curve_edge_button.setEnabled(bool(enabled))
         self.calculate_angle_button.setEnabled(bool(enabled))
         if not enabled:
@@ -189,10 +222,41 @@ class GraphPanel(QWidget):
             self.calculate_angle_button.setChecked(False)
             self.calculate_angle_button.blockSignals(was_blocked)
 
-    def set_visible_checked(self, visible: bool) -> None:
-        was_blocked = self.visible_checkbox.blockSignals(True)
-        self.visible_checkbox.setChecked(bool(visible))
-        self.visible_checkbox.blockSignals(was_blocked)
+    def set_projected_graph_layers(
+        self,
+        layers: tuple[tuple[str, str], ...],
+        selected_layer_id: str | None,
+    ) -> None:
+        was_blocked = self.projected_graph_combo.blockSignals(True)
+        self.projected_graph_combo.clear()
+        self.projected_graph_combo.addItem("---", None)
+        selected_index = 0
+        for layer_id, display_name in layers:
+            self.projected_graph_combo.addItem(display_name, layer_id)
+            if layer_id == selected_layer_id:
+                selected_index = self.projected_graph_combo.count() - 1
+        self.projected_graph_combo.setCurrentIndex(selected_index)
+        self.projected_graph_combo.blockSignals(was_blocked)
+
+    def set_projected_graph_state(
+        self,
+        *,
+        enabled: bool,
+        available: bool,
+        status: str = "",
+        warning: bool = False,
+    ) -> None:
+        self.projection_toggle_button.setText(
+            "Disable Projecting 3D Graph"
+            if enabled
+            else "Enable Projecting 3D Graph"
+        )
+        self.projection_toggle_button.setEnabled(bool(available or enabled))
+        self.projection_status_label.setText(status)
+        self.projection_status_label.setVisible(bool(status))
+        self.projection_status_label.setStyleSheet(
+            "color: #ffb74d;" if warning else ""
+        )
 
     def set_opacity(self, opacity: float) -> None:
         value = int(round(min(max(float(opacity), 0.0), 1.0) * 100.0))

--- a/src/mipview/ui/main_window.py
+++ b/src/mipview/ui/main_window.py
@@ -74,10 +74,16 @@ from mipview.ui.window_styling import (
     ResponsiveFontScaler,
     apply_window_content_frame,
 )
+from mipview.viewer.orientation_indicator import (
+    ORIENTATION_INDICATOR_LABELS,
+    ORIENTATION_INDICATOR_OFF,
+    ORIENTATION_INDICATOR_WIDGET,
+)
 from mipview.viewer.triplanar_viewer_widget import (
     VIEW_MODE_3D,
     VIEW_MODE_AXIAL,
     VIEW_MODE_CORONAL,
+    VIEW_MODE_ORTHOGONAL,
     VIEW_MODE_ORTHOGONAL_3D,
     VIEW_MODE_SAGITTAL,
     TriPlanarViewerWidget,
@@ -120,6 +126,8 @@ class MainWindow(QMainWindow):
         self.cursor_overlay_action: QAction | None = None
         self.view_mode_actions: dict[str, QAction] = {}
         self.view_mode_action_group: QActionGroup | None = None
+        self.orientation_indicator_actions: dict[str, QAction] = {}
+        self.orientation_indicator_action_group: QActionGroup | None = None
         self.ruler_action: QAction | None = None
         self._cursor_overlay_checked_before_patch = True
         self.patch_toggle_action: QAction | None = None
@@ -220,7 +228,12 @@ class MainWindow(QMainWindow):
         right_layout.setSpacing(0)
         right_layout.addWidget(self.cursor_panel)
         right_layout.addWidget(self.annotation_panel)
-        right_layout.addWidget(self.volume_3d_panel)
+        volume_3d_panel_container = QWidget(right_panel)
+        volume_3d_panel_layout = QVBoxLayout(volume_3d_panel_container)
+        volume_3d_panel_layout.setContentsMargins(8, 0, 8, 8)
+        volume_3d_panel_layout.setSpacing(0)
+        volume_3d_panel_layout.addWidget(self.volume_3d_panel)
+        right_layout.addWidget(volume_3d_panel_container)
         right_layout.addStretch(1)
 
         right_scroll_area = QScrollArea(self)
@@ -293,6 +306,8 @@ class MainWindow(QMainWindow):
             self.slice_viewer.set_cursor_overlay_visible
         )
         view_menu.addAction(self.cursor_overlay_action)
+        view_menu.addSeparator()
+        self._add_orientation_indicator_actions(view_menu)
 
         self.patch_toggle_action = QAction("&Patch Selection", self)
         self.patch_toggle_action.setCheckable(True)
@@ -344,6 +359,7 @@ class MainWindow(QMainWindow):
             ("Sagittal View", VIEW_MODE_SAGITTAL),
             ("Coronal View", VIEW_MODE_CORONAL),
             ("3D Render", VIEW_MODE_3D),
+            ("Orthogonal", VIEW_MODE_ORTHOGONAL),
             ("Orthogonal and 3D", VIEW_MODE_ORTHOGONAL_3D),
         )
         for label, mode in labels:
@@ -366,6 +382,31 @@ class MainWindow(QMainWindow):
         action = self.view_mode_actions.get(mode)
         if action is not None:
             action.setChecked(True)
+
+    def _add_orientation_indicator_actions(self, view_menu: object) -> None:
+        action_group = QActionGroup(self)
+        action_group.setExclusive(True)
+        self.orientation_indicator_action_group = action_group
+        for label, mode in (
+            ("Display orientation labels", ORIENTATION_INDICATOR_LABELS),
+            ("Display orientation widget", ORIENTATION_INDICATOR_WIDGET),
+            ("Turn off Orientation Indicator", ORIENTATION_INDICATOR_OFF),
+        ):
+            action = QAction(label, self)
+            action.setCheckable(True)
+            action.setChecked(
+                mode == self.slice_viewer.orientation_indicator_mode()
+            )
+            action.triggered.connect(
+                lambda _checked=False, selected_mode=mode: (
+                    self.slice_viewer.set_orientation_indicator_mode(
+                        selected_mode
+                    )
+                )
+            )
+            action_group.addAction(action)
+            view_menu.addAction(action)
+            self.orientation_indicator_actions[mode] = action
 
     def resizeEvent(self, event: QResizeEvent) -> None:
         super().resizeEvent(event)

--- a/src/mipview/ui/main_window.py
+++ b/src/mipview/ui/main_window.py
@@ -62,7 +62,9 @@ from mipview.ui.cursor_panel import CursorInspectionPanel
 from mipview.ui.drop_load_choice_dialog import DropLoadChoice, DropLoadChoiceDialog
 from mipview.ui.drop_loading import (
     first_supported_local_drop_path,
+    is_supported_graphml_path,
     is_supported_graph_state_path,
+    is_supported_nifti_path,
 )
 from mipview.ui.overlay_opacity_control_bar import OverlayOpacityControlBar
 from mipview.ui.patch_window import PatchViewerWindow
@@ -89,6 +91,11 @@ from mipview.viewer.triplanar_viewer_widget import (
     TriPlanarViewerWidget,
 )
 from mipview.viewer.render_3d_state import Render3DSource
+from mipview.vessel_graph import (
+    VesselGraphRenderGeometry,
+    full_vessel_graph_geometry,
+    load_vessel_graphml,
+)
 
 ANNOTATION_LOAD_FILTER = (
     "Annotation Files (*.nii *.nii.gz *.json);;"
@@ -116,7 +123,10 @@ class MainWindow(QMainWindow):
         self.slice_viewer = TriPlanarViewerWidget(maximum_zoom=25.0)
         self.cursor_panel = CursorInspectionPanel(adaptable_width=True)
         self.annotation_panel = AnnotationPanel(adaptable_width=True)
-        self.volume_3d_panel = Volume3DPanel(self)
+        self.volume_3d_panel = Volume3DPanel(
+            self,
+            allow_vessel_graph_unload=True,
+        )
         self.slice_viewer.volume_3d_view.connect_panel(self.volume_3d_panel)
         self.contrast_control_bar = ContrastControlBar(self)
         self.overlay_opacity_control_bar = OverlayOpacityControlBar(
@@ -140,6 +150,7 @@ class MainWindow(QMainWindow):
         self._patch_windows: list[PatchViewerWindow] = []
         self._content_widget: QWidget | None = None
         self._main_splitter: QSplitter | None = None
+        self._syncing_main_vessel_3d = False
         self.segmentation_config_window = SegmentationConfigWindow(self)
         self.setAcceptDrops(True)
         self._loading_hide_timer.setSingleShot(True)
@@ -167,6 +178,9 @@ class MainWindow(QMainWindow):
             self.annotation_panel.set_undo_available
         )
         self.slice_viewer.nifti_file_dropped.connect(self._on_viewer_nifti_file_dropped)
+        self.slice_viewer.graphml_file_dropped.connect(
+            self._on_viewer_graphml_file_dropped
+        )
         self.slice_viewer.graph_state_file_dropped.connect(
             self._on_viewer_graph_state_file_dropped
         )
@@ -196,6 +210,12 @@ class MainWindow(QMainWindow):
             self._on_annotation_brush_mode_changed
         )
         self.annotation_panel.undo_requested.connect(self._on_annotation_undo_requested)
+        self.volume_3d_panel.vessel_graph_unload_requested.connect(
+            self._on_unload_vessel_graph
+        )
+        self.slice_viewer.volume_3d_view.state_changed.connect(
+            self._on_render3d_state_changed
+        )
         connect_contrast_controls(
             self.contrast_control_bar,
             self.contrast_state,
@@ -281,6 +301,7 @@ class MainWindow(QMainWindow):
         file_menu = self.menuBar().addMenu("&File")
         view_menu = self.menuBar().addMenu("&View")
         segmentation_menu = self.menuBar().addMenu("&Segmentation")
+        graph_menu = self.menuBar().addMenu("&Graph")
         tools_menu = self.menuBar().addMenu("&Tools")
 
         open_action = QAction("&Open", self)
@@ -361,6 +382,10 @@ class MainWindow(QMainWindow):
             self._on_open_segmentation_configuration
         )
         segmentation_menu.addAction(self.open_segmentation_config_action)
+
+        load_graphml_action = QAction("Load &GraphML…", self)
+        load_graphml_action.triggered.connect(self._on_load_vessel_graphs)
+        graph_menu.addAction(load_graphml_action)
 
     def _add_view_mode_actions(self, view_menu: object) -> None:
         action_group = QActionGroup(self)
@@ -470,6 +495,7 @@ class MainWindow(QMainWindow):
         self.state.selected_patch_data = None
         self._clear_annotation_session()
         self._clear_segmentation_session()
+        self._clear_vessel_graph_session()
         self._set_patch_selection_active(False)
         if self.cursor_overlay_action is not None:
             self.cursor_overlay_action.setEnabled(True)
@@ -589,6 +615,7 @@ class MainWindow(QMainWindow):
                 None if active_segmentation is None else active_segmentation.kind
             ),
             projection_mask_layers=self._projection_mask_layers_for_bounds(bounds),
+            vessel_graph_layers=self.state.loaded_vessel_graphs,
             segmentation_opacity=self.state.segmentation_opacity,
             annotation_mask=active_annotation_patch,
             annotation_opacity=self.state.annotation.opacity,
@@ -1472,8 +1499,181 @@ class MainWindow(QMainWindow):
         if loaded_count > 0:
             self.statusBar().showMessage(f"Loaded {loaded_count} segmentation file(s)")
 
+    def _on_load_vessel_graphs(self) -> None:
+        if self.state.volume is None:
+            QMessageBox.warning(
+                self,
+                "No Image Loaded",
+                "Load a base image before loading GraphML vessel graphs.",
+            )
+            return
+        selected_files, _ = QFileDialog.getOpenFileNames(
+            self,
+            "Load Vessel GraphML",
+            "",
+            "GraphML Files (*.graphml);;All Files (*)",
+        )
+        for selected_file in selected_files:
+            self._load_vessel_graph_from_path(Path(selected_file))
+
+    def _load_vessel_graph_from_path(self, path: Path) -> bool:
+        try:
+            layer, already_loaded = self.load_vessel_graph(path)
+        except (FileNotFoundError, OSError, ValueError) as exc:
+            QMessageBox.warning(self, "GraphML Load Failed", str(exc))
+            self.statusBar().showMessage("GraphML load failed")
+            return False
+        if already_loaded:
+            self.statusBar().showMessage(f"GraphML already loaded: {path.name}")
+            return True
+        if layer.warnings:
+            QMessageBox.warning(
+                self,
+                "GraphML Loaded with Spatial Warning",
+                "\n".join(layer.warnings)
+                + "\n\nPatch projections are disabled for this layer.",
+            )
+        self.statusBar().showMessage(
+            f"Loaded GraphML {path.name}: {layer.data.node_count} nodes, "
+            f"{layer.data.edge_count} edges"
+        )
+        return True
+
+    def load_vessel_graph(
+        self,
+        path: str | Path,
+    ):
+        if self.state.volume is None:
+            raise ValueError(
+                "Load a base image before loading GraphML vessel graphs."
+            )
+        graph_path = Path(path)
+        resolved = graph_path.resolve(strict=False)
+        existing = next(
+            (
+                layer
+                for layer in self.state.loaded_vessel_graphs
+                if layer.path == resolved
+            ),
+            None,
+        )
+        if existing is not None:
+            self.state.active_vessel_graph_id = existing.id
+            self._on_vessel_graph_layer_changed(existing.id)
+            return existing, True
+        layer = load_vessel_graphml(graph_path, self.state.volume)
+        layer.settings.visible = True
+        self.state.loaded_vessel_graphs.append(layer)
+        self.state.active_vessel_graph_id = layer.id
+        self._sync_volume_3d_sources()
+        self._sync_patch_windows_vessel_graphs()
+        self._on_vessel_graph_layer_changed(layer.id)
+        return layer, False
+
+    def _on_unload_vessel_graph(self, layer_id: object) -> None:
+        if not isinstance(layer_id, str):
+            return
+        try:
+            self.unload_vessel_graph(layer_id)
+        except ValueError:
+            return
+        self.statusBar().showMessage("GraphML layer unloaded")
+
+    def unload_vessel_graph(self, layer_id: str):
+        removed = next(
+            (
+                layer
+                for layer in self.state.loaded_vessel_graphs
+                if layer.id == layer_id
+            ),
+            None,
+        )
+        if removed is None:
+            raise ValueError(f"GraphML layer does not exist: {layer_id}")
+        self.state.loaded_vessel_graphs = [
+            layer
+            for layer in self.state.loaded_vessel_graphs
+            if layer.id != layer_id
+        ]
+        self.state.active_vessel_graph_id = (
+            self.state.loaded_vessel_graphs[0].id
+            if self.state.loaded_vessel_graphs
+            else None
+        )
+        self._sync_volume_3d_sources()
+        self._sync_patch_windows_vessel_graphs()
+        return removed
+
+    def _active_vessel_graph(self):
+        layer_id = self.state.active_vessel_graph_id
+        return next(
+            (
+                layer
+                for layer in self.state.loaded_vessel_graphs
+                if layer.id == layer_id
+            ),
+            None,
+        )
+
+    def _on_vessel_graph_layer_changed(self, layer_id: object) -> None:
+        self.state.active_vessel_graph_id = (
+            layer_id if isinstance(layer_id, str) else None
+        )
+        layer = self._active_vessel_graph()
+        if layer is not None:
+            target = self.slice_viewer.volume_3d_view
+            if layer.id in target.state.sources:
+                self._syncing_main_vessel_3d = True
+                try:
+                    target.select_source(layer.id)
+                    target.set_selected_visibility(layer.settings.visible)
+                    target.set_selected_opacity(layer.settings.opacity)
+                    target.set_selected_node_size(layer.settings.node_size)
+                    target.set_selected_edge_thickness(
+                        layer.settings.edge_thickness
+                    )
+                finally:
+                    self._syncing_main_vessel_3d = False
+
+    def _on_render3d_state_changed(self, status: object) -> None:
+        if self._syncing_main_vessel_3d:
+            return
+        if not isinstance(status, dict):
+            return
+        layer_id = status.get("selected_source_id")
+        layer = next(
+            (
+                candidate
+                for candidate in self.state.loaded_vessel_graphs
+                if candidate.id == layer_id
+            ),
+            None,
+        )
+        if layer is None:
+            return
+        settings = self.slice_viewer.volume_3d_view.state.settings.get(layer.id)
+        if settings is None:
+            return
+        layer.settings.visible = settings.visible
+        layer.settings.set_opacity(settings.opacity)
+        layer.settings.set_node_size(settings.node_size)
+        layer.settings.set_edge_thickness(settings.edge_thickness)
+        self.state.active_vessel_graph_id = layer.id
+
+    def _sync_patch_windows_vessel_graphs(self) -> None:
+        for patch_window in self._patch_windows_for_current_image():
+            patch_window.update_vessel_graph_layers(
+                self.state.loaded_vessel_graphs
+            )
+
+    def _clear_vessel_graph_session(self) -> None:
+        self.state.loaded_vessel_graphs = []
+        self.state.active_vessel_graph_id = None
+        for patch_window in tuple(self._patch_windows):
+            patch_window.update_vessel_graph_layers(())
+
     def _on_viewer_nifti_file_dropped(self, dropped_path: Path) -> None:
-        choice = self._prompt_drop_load_choice()
+        choice = self._prompt_drop_load_choice(dropped_path)
         if choice is None:
             self.statusBar().showMessage("Dropped file load canceled")
             return
@@ -1481,6 +1681,13 @@ class MainWindow(QMainWindow):
             self._load_base_image_from_path(dropped_path)
             return
         self._load_segmentation_from_path(dropped_path)
+
+    def _on_viewer_graphml_file_dropped(self, dropped_path: Path) -> None:
+        choice = self._prompt_drop_load_choice(dropped_path)
+        if choice != DropLoadChoice.GRAPH:
+            self.statusBar().showMessage("Dropped GraphML load canceled")
+            return
+        self._load_vessel_graph_from_path(dropped_path)
 
     def _on_viewer_graph_state_file_dropped(self, dropped_path: Path) -> None:
         choice = QMessageBox.question(
@@ -1754,7 +1961,38 @@ class MainWindow(QMainWindow):
             )
             for segmentation in self.state.loaded_segmentations
         )
-        self.slice_viewer.volume_3d_view.set_sources(sources)
+        for layer in self.state.loaded_vessel_graphs:
+            polylines, nodes = full_vessel_graph_geometry(
+                layer.data,
+                use_centerlines=layer.projection_safe,
+            )
+            sources.append(
+                Render3DSource(
+                    id=layer.id,
+                    display_name=layer.display_name,
+                    volume=None,
+                    kind="vessel_graph",
+                    vessel_graph=VesselGraphRenderGeometry(
+                        polylines_world=polylines,
+                        node_world_positions=nodes,
+                    ),
+                )
+            )
+        self._syncing_main_vessel_3d = True
+        try:
+            self.slice_viewer.volume_3d_view.set_sources(sources)
+            for layer in self.state.loaded_vessel_graphs:
+                settings = self.slice_viewer.volume_3d_view.state.settings.get(
+                    layer.id
+                )
+                if settings is None:
+                    continue
+                settings.visible = layer.settings.visible
+                settings.set_opacity(layer.settings.opacity)
+                settings.set_node_size(layer.settings.node_size)
+                settings.set_edge_thickness(layer.settings.edge_thickness)
+        finally:
+            self._syncing_main_vessel_3d = False
 
     def _clear_segmentation_session(self) -> None:
         self.state.segmentation_image_path = None
@@ -1793,6 +2031,18 @@ class MainWindow(QMainWindow):
             patch_window.graph_status()
             for patch_window in self._patch_windows_for_current_image()
         ]
+
+    def vessel_graph_status(self) -> dict[str, object]:
+        return {
+            "active_layer_id": self.state.active_vessel_graph_id,
+            "layers": [
+                layer.status() for layer in self.state.loaded_vessel_graphs
+            ],
+            "patch_sessions": [
+                patch_window.vessel_graph_status()
+                for patch_window in self._patch_windows_for_current_image()
+            ],
+        }
 
     def _update_patch_windows_segmentation_for_current_image(
         self,
@@ -1938,6 +2188,8 @@ class MainWindow(QMainWindow):
         event.acceptProposedAction()
         if is_supported_graph_state_path(dropped_path):
             self._on_viewer_graph_state_file_dropped(dropped_path)
+        elif is_supported_graphml_path(dropped_path):
+            self._on_viewer_graphml_file_dropped(dropped_path)
         else:
             self._on_viewer_nifti_file_dropped(dropped_path)
         return True
@@ -1960,9 +2212,16 @@ class MainWindow(QMainWindow):
         viewer_top_left = self.slice_viewer.mapFromGlobal(source_widget.mapToGlobal(point))
         return self.slice_viewer.rect().contains(viewer_top_left)
 
-    def _prompt_drop_load_choice(self) -> DropLoadChoice | None:
+    def _prompt_drop_load_choice(
+        self,
+        dropped_path: Path,
+    ) -> DropLoadChoice | None:
+        is_graphml = is_supported_graphml_path(dropped_path)
+        is_nifti = is_supported_nifti_path(dropped_path)
         dialog = DropLoadChoiceDialog(
-            allow_segmentation=self.state.volume is not None,
+            allow_base_image=is_nifti,
+            allow_segmentation=is_nifti and self.state.volume is not None,
+            allow_graph=is_graphml and self.state.volume is not None,
             parent=self,
         )
         if dialog.exec() != dialog.DialogCode.Accepted:
@@ -1995,6 +2254,7 @@ class MainWindow(QMainWindow):
         self.state.selected_patch_bounds = None
         self.state.selected_patch_data = None
         self._clear_annotation_session()
+        self._clear_vessel_graph_session()
         cleared_count = self._reset_segmentation_session_for_loaded_image(image_path)
         self._sync_volume_3d_sources()
         self._initialize_contrast_for_loaded_volume()

--- a/src/mipview/ui/main_window.py
+++ b/src/mipview/ui/main_window.py
@@ -128,6 +128,7 @@ class MainWindow(QMainWindow):
         self.view_mode_action_group: QActionGroup | None = None
         self.orientation_indicator_actions: dict[str, QAction] = {}
         self.orientation_indicator_action_group: QActionGroup | None = None
+        self.patch_extension_lines_action: QAction | None = None
         self.ruler_action: QAction | None = None
         self._cursor_overlay_checked_before_patch = True
         self.patch_toggle_action: QAction | None = None
@@ -308,6 +309,17 @@ class MainWindow(QMainWindow):
         view_menu.addAction(self.cursor_overlay_action)
         view_menu.addSeparator()
         self._add_orientation_indicator_actions(view_menu)
+        view_menu.addSeparator()
+        self.patch_extension_lines_action = QAction(
+            "Turn on/off patch indicator extension lines",
+            self,
+        )
+        self.patch_extension_lines_action.setCheckable(True)
+        self.patch_extension_lines_action.setChecked(True)
+        self.patch_extension_lines_action.toggled.connect(
+            self.slice_viewer.volume_3d_view.set_patch_extension_lines_visible
+        )
+        view_menu.addAction(self.patch_extension_lines_action)
 
         self.patch_toggle_action = QAction("&Patch Selection", self)
         self.patch_toggle_action.setCheckable(True)

--- a/src/mipview/ui/patch_window.py
+++ b/src/mipview/ui/patch_window.py
@@ -92,6 +92,11 @@ from mipview.ui.window_styling import (
 )
 from mipview.viewer.intensity import normalize_slice_to_uint8, window_slice_to_uint8
 from mipview.viewer.oriented_volume import build_oriented_volume
+from mipview.viewer.orientation_indicator import (
+    ORIENTATION_INDICATOR_LABELS,
+    ORIENTATION_INDICATOR_OFF,
+    ORIENTATION_INDICATOR_WIDGET,
+)
 from mipview.viewer.ruler import display_voxel_spacing_mm, spatial_unit_to_mm
 from mipview.viewer.slice_geometry import project_oriented_volume
 from mipview.viewer.slice_geometry import Orientation, plane_axes_for_orientation
@@ -99,6 +104,7 @@ from mipview.viewer.triplanar_viewer_widget import (
     VIEW_MODE_3D,
     VIEW_MODE_AXIAL,
     VIEW_MODE_CORONAL,
+    VIEW_MODE_ORTHOGONAL,
     VIEW_MODE_ORTHOGONAL_3D,
     VIEW_MODE_SAGITTAL,
     TriPlanarViewerWidget,
@@ -469,6 +475,7 @@ class PatchViewerWindow(QMainWindow):
             ("Sagittal View", VIEW_MODE_SAGITTAL),
             ("Coronal View", VIEW_MODE_CORONAL),
             ("3D Render", VIEW_MODE_3D),
+            ("Orthogonal", VIEW_MODE_ORTHOGONAL),
             ("Orthogonal and 3D", VIEW_MODE_ORTHOGONAL_3D),
         ):
             action = QAction(label, self)
@@ -494,6 +501,31 @@ class PatchViewerWindow(QMainWindow):
             self.slice_viewer.set_cursor_overlay_visible
         )
         view_menu.addAction(self.cursor_overlay_action)
+        view_menu.addSeparator()
+
+        self.orientation_indicator_actions: dict[str, QAction] = {}
+        self.orientation_indicator_action_group = QActionGroup(self)
+        self.orientation_indicator_action_group.setExclusive(True)
+        for label, mode in (
+            ("Display orientation labels", ORIENTATION_INDICATOR_LABELS),
+            ("Display orientation widget", ORIENTATION_INDICATOR_WIDGET),
+            ("Turn off Orientation Indicator", ORIENTATION_INDICATOR_OFF),
+        ):
+            action = QAction(label, self)
+            action.setCheckable(True)
+            action.setChecked(
+                mode == self.slice_viewer.orientation_indicator_mode()
+            )
+            action.triggered.connect(
+                lambda _checked=False, selected_mode=mode: (
+                    self.slice_viewer.set_orientation_indicator_mode(
+                        selected_mode
+                    )
+                )
+            )
+            self.orientation_indicator_action_group.addAction(action)
+            view_menu.addAction(action)
+            self.orientation_indicator_actions[mode] = action
 
         self.segmentation_menu = self.menuBar().addMenu("&Segmentation")
         self.unload_current_segmentation_action = QAction(

--- a/src/mipview/ui/patch_window.py
+++ b/src/mipview/ui/patch_window.py
@@ -110,6 +110,13 @@ from mipview.viewer.triplanar_viewer_widget import (
     TriPlanarViewerWidget,
 )
 from mipview.viewer.render_3d_state import Render3DSource
+from mipview.vessel_graph import (
+    ClippedVesselGraph,
+    VesselGraphDisplaySettings,
+    VesselGraphLayer,
+    VesselGraphRenderGeometry,
+    clip_vessel_graph_to_patch,
+)
 
 
 class PatchViewerWindow(QMainWindow):
@@ -154,6 +161,7 @@ class PatchViewerWindow(QMainWindow):
         projection_mask_layers: Sequence[
             tuple[str, str, NiftiLoadResult]
         ] | None = None,
+        vessel_graph_layers: Sequence[VesselGraphLayer] | None = None,
         active_segmentation_kind: str | None = None,
     ) -> None:
         super().__init__(parent)
@@ -205,6 +213,11 @@ class PatchViewerWindow(QMainWindow):
         self._annotation_visible = bool(annotation_visible)
         self._annotation_active_label = max(int(annotation_active_label), 0)
         self.graph_state = ProjectionGraphState()
+        self._vessel_graph_layers: dict[str, VesselGraphLayer] = {}
+        self._vessel_graph_settings: dict[str, VesselGraphDisplaySettings] = {}
+        self._clipped_vessel_graphs: dict[str, ClippedVesselGraph] = {}
+        self._active_vessel_graph_id: str | None = None
+        self._syncing_patch_vessel_3d = False
         self._graph_projection_mode = "MIP"
         self._patch_history = PatchHistoryManager(
             patch_volume.data,
@@ -376,7 +389,12 @@ class PatchViewerWindow(QMainWindow):
         self.graph_panel.activation_requested.connect(
             self._on_graph_activation_requested
         )
-        self.graph_panel.visibility_changed.connect(self._on_graph_visibility_changed)
+        self.graph_panel.projection_layer_changed.connect(
+            self._on_vessel_graph_layer_changed
+        )
+        self.graph_panel.projection_toggle_requested.connect(
+            self._on_vessel_graph_projection_toggle_requested
+        )
         self.graph_panel.opacity_changed.connect(self._on_graph_opacity_changed)
         self.graph_panel.node_size_changed.connect(self._on_graph_node_size_changed)
         self.graph_panel.edge_thickness_changed.connect(
@@ -401,6 +419,9 @@ class PatchViewerWindow(QMainWindow):
         self.graph_panel.load_state_requested.connect(
             self._on_load_graph_state_requested
         )
+        self.slice_viewer.volume_3d_view.state_changed.connect(
+            self._on_patch_render3d_state_changed
+        )
         self._graph_cancel_shortcut = QShortcut(
             QKeySequence(QKeySequence.StandardKey.Cancel),
             self,
@@ -413,6 +434,7 @@ class PatchViewerWindow(QMainWindow):
             self._on_auto_contrast,
         )
         self.slice_viewer.load_volume(patch_volume)
+        self.update_vessel_graph_layers(vessel_graph_layers or ())
         self.update_projection_mask_layers(projection_mask_layers or ())
         self.slice_viewer.set_projection_graph_state(self.graph_state)
         if segmentation_volume is not None:
@@ -653,7 +675,7 @@ class PatchViewerWindow(QMainWindow):
 
         form.addRow("Mode:", self.projection_mode_combo)
         form.addRow("Mask:", self.projection_mask_combo)
-        form.addRow("MIP the segmentation:", self.projection_segmentation_checkbox)
+        form.addRow("MIP The Overlay:", self.projection_segmentation_checkbox)
         form.addRow("Direction:", direction_row)
         return panel
 
@@ -853,6 +875,77 @@ class PatchViewerWindow(QMainWindow):
         summary["layers"] = layers
         return summary
 
+    def vessel_graph_status(self) -> dict[str, object]:
+        return {
+            "session_id": self.graph_session_id,
+            "active_layer_id": self._active_vessel_graph_id,
+            "layers": [
+                {
+                    **layer.status(),
+                    "patch_settings": {
+                        "visible": self._vessel_graph_settings[layer.id].visible,
+                        "opacity": self._vessel_graph_settings[layer.id].opacity,
+                        "node_size": self._vessel_graph_settings[layer.id].node_size,
+                        "edge_thickness": (
+                            self._vessel_graph_settings[layer.id].edge_thickness
+                        ),
+                    },
+                    "patch_path_count": (
+                        0
+                        if layer.id not in self._clipped_vessel_graphs
+                        else len(
+                            self._clipped_vessel_graphs[
+                                layer.id
+                            ].polylines_world
+                        )
+                    ),
+                }
+                for layer in self._vessel_graph_layers.values()
+            ],
+        }
+
+    def select_vessel_graph_layer(self, layer_id: str) -> None:
+        if layer_id not in self._vessel_graph_layers:
+            raise ValueError(f"GraphML layer does not exist: {layer_id}")
+        self._active_vessel_graph_id = layer_id
+        self._refresh_vessel_graph_panel()
+        self._refresh_vessel_graph_projection()
+
+    def set_vessel_graph_display(
+        self,
+        layer_id: str,
+        *,
+        visible: bool | None = None,
+        opacity: float | None = None,
+        node_size: int | None = None,
+        edge_thickness: int | None = None,
+    ) -> None:
+        self.select_vessel_graph_layer(layer_id)
+        layer = self._vessel_graph_layers[layer_id]
+        if visible and not layer.projection_safe:
+            raise ValueError(
+                "This GraphML layer has a spatial mismatch; patch projections "
+                "remain disabled."
+            )
+        settings = self._vessel_graph_settings[layer_id]
+        if visible is not None:
+            if visible:
+                for candidate_id, candidate in self._vessel_graph_settings.items():
+                    candidate.visible = candidate_id == layer_id
+                if self.graph_state.editing_enabled:
+                    self.set_graph_editing_enabled(False)
+                self.set_graph_display_options(visible=False)
+            else:
+                settings.visible = False
+        if opacity is not None:
+            self.set_graph_display_options(opacity=opacity)
+        if node_size is not None:
+            self.set_graph_display_options(node_size=node_size)
+        if edge_thickness is not None:
+            self.set_graph_display_options(edge_thickness=edge_thickness)
+        self._refresh_vessel_graph_panel()
+        self._refresh_vessel_graph_projection()
+
     def save_graph_state(
         self,
         path: str | Path,
@@ -892,10 +985,10 @@ class PatchViewerWindow(QMainWindow):
         self.graph_state.editing_enabled = editing_enabled
         self.graph_state.active_orientation = active_orientation
         self.slice_viewer.set_projection_graph_state(self.graph_state)
-        self.graph_panel.set_visible_checked(self.graph_state.visible)
         self.graph_panel.set_opacity(self.graph_state.opacity)
         self.graph_panel.set_node_size(self.graph_state.node_size)
         self.graph_panel.set_edge_thickness(self.graph_state.edge_thickness)
+        self._apply_2d_graph_style_to_vessel_projections()
         self.graph_panel.set_editing_enabled(editing_enabled)
         self.restore_projection_settings(
             result.projection_mode,
@@ -1022,8 +1115,8 @@ class PatchViewerWindow(QMainWindow):
         enabled_orientations = self.slice_viewer.enabled_projection_orientations()
         if not enabled_orientations:
             raise ValueError("Enable at least one MIP/MinIP projection first.")
+        self._hide_all_vessel_graph_layers()
         self.graph_state.visible = True
-        self.graph_panel.set_visible_checked(True)
         active_view = self.slice_viewer.active_view()
         if active_view in enabled_orientations:
             self.graph_state.active_orientation = active_view
@@ -1045,8 +1138,9 @@ class PatchViewerWindow(QMainWindow):
         edge_thickness: int | None = None,
     ) -> None:
         if visible is not None:
+            if visible:
+                self._hide_all_vessel_graph_layers()
             self.graph_state.visible = bool(visible)
-            self.graph_panel.set_visible_checked(self.graph_state.visible)
             if not self.graph_state.visible:
                 self.graph_state.cancel_pending_edge()
                 self.graph_state.cancel_pending_vector()
@@ -1060,8 +1154,33 @@ class PatchViewerWindow(QMainWindow):
         if edge_thickness is not None:
             self.graph_state.set_edge_thickness(edge_thickness)
             self.graph_panel.set_edge_thickness(self.graph_state.edge_thickness)
+        if (
+            opacity is not None
+            or node_size is not None
+            or edge_thickness is not None
+        ):
+            self._apply_2d_graph_style_to_vessel_projections()
         self.slice_viewer.refresh_graph_overlay()
+        self._refresh_vessel_graph_projection()
         self._refresh_graph_panel_tool_state()
+
+    def _hide_all_vessel_graph_layers(self) -> None:
+        changed = False
+        for settings in self._vessel_graph_settings.values():
+            if settings.visible:
+                settings.visible = False
+                changed = True
+        if not changed:
+            return
+        self._refresh_vessel_graph_panel()
+        self._refresh_vessel_graph_projection()
+
+    def _apply_2d_graph_style_to_vessel_projections(self) -> None:
+        for settings in self._vessel_graph_settings.values():
+            settings.set_opacity(self.graph_state.opacity)
+            settings.set_node_size(self.graph_state.node_size)
+            settings.set_edge_thickness(self.graph_state.edge_thickness)
+        self._sync_shared_graph_sizes_to_3d()
 
     def add_graph_node(
         self,
@@ -1389,7 +1508,7 @@ class PatchViewerWindow(QMainWindow):
 
     def _validate_graph_editing(self) -> None:
         if not self.graph_state.editing_enabled:
-            raise ValueError("Graph mode is not active.")
+            raise ValueError("Graph creation is not enabled.")
         if not self.graph_state.visible:
             raise ValueError("Graph visibility must be enabled before editing.")
         if not self.slice_viewer.enabled_projection_orientations():
@@ -1403,11 +1522,10 @@ class PatchViewerWindow(QMainWindow):
             self.statusBar().showMessage(str(exc))
             return
         self.statusBar().showMessage(
-            "Graph mode activated" if enabled else "Graph mode exited"
+            "Graph creation enabled"
+            if enabled
+            else "Graph creation disabled; created graph remains visible"
         )
-
-    def _on_graph_visibility_changed(self, visible: bool) -> None:
-        self.set_graph_display_options(visible=visible)
 
     def _on_graph_opacity_changed(self, opacity: float) -> None:
         self.set_graph_display_options(opacity=opacity)
@@ -1436,10 +1554,11 @@ class PatchViewerWindow(QMainWindow):
             self.graph_state.cancel_pending_vector()
             self.graph_state.cancel_active_tool()
         self.graph_panel.set_projection_available(bool(enabled))
+        self._refresh_vessel_graph_panel()
         if self.graph_state.editing_enabled and not enabled:
             self.set_graph_editing_enabled(False)
             self.statusBar().showMessage(
-                "Graph mode exited because all projections were disabled"
+                "Graph creation was disabled because all projections were disabled"
             )
             return
         if self.graph_state.active_orientation not in enabled:
@@ -2382,7 +2501,7 @@ class PatchViewerWindow(QMainWindow):
     def _on_save_graph_state_requested(self) -> None:
         selected_path, _ = QFileDialog.getSaveFileName(
             self,
-            "Save Graph State",
+            "Save Created Graph State",
             self._default_graph_state_filename(),
             "MipView Graph State (*.mipgraph.json);;JSON Files (*.json);;All Files (*)",
         )
@@ -2392,7 +2511,11 @@ class PatchViewerWindow(QMainWindow):
         try:
             saved_path = self.save_graph_state(selected_path, overwrite=True)
         except (OSError, ValueError) as exc:
-            QMessageBox.critical(self, "Save Graph State Failed", str(exc))
+            QMessageBox.critical(
+                self,
+                "Save Created Graph State Failed",
+                str(exc),
+            )
             self.statusBar().showMessage("Graph state save failed")
             return
         self.statusBar().showMessage(f"Graph state saved: {saved_path}")
@@ -2400,7 +2523,7 @@ class PatchViewerWindow(QMainWindow):
     def _on_load_graph_state_requested(self) -> None:
         selected_path, _ = QFileDialog.getOpenFileName(
             self,
-            "Load Graph State",
+            "Load Created Graph State",
             str(Path(self._default_graph_state_filename()).parent),
             "MipView Graph State (*.mipgraph.json);;JSON Files (*.json);;All Files (*)",
         )
@@ -2423,7 +2546,11 @@ class PatchViewerWindow(QMainWindow):
         try:
             result = self.load_graph_state(selected_path, replace=replace)
         except (OSError, ValueError) as exc:
-            QMessageBox.critical(self, "Load Graph State Failed", str(exc))
+            QMessageBox.critical(
+                self,
+                "Load Created Graph State Failed",
+                str(exc),
+            )
             self.statusBar().showMessage("Graph state load failed")
             return
         count_text = ", ".join(
@@ -2978,6 +3105,7 @@ class PatchViewerWindow(QMainWindow):
             self._patch_size = expected_shape
             self._patch_volume = patch_volume
             self._patch_data = patch_volume.data
+            self._rebuild_clipped_vessel_graphs()
             self._patch_history.reset(patch_volume.data)
             self._replace_patch_viewer_volume(patch_volume)
             self.update_segmentation_overlay(
@@ -2995,6 +3123,8 @@ class PatchViewerWindow(QMainWindow):
                 brush_mode=self.annotation_panel.current_brush_mode(),
             )
             self.update_projection_mask_layers(projection_mask_layers)
+            self._refresh_vessel_graph_panel()
+            self._refresh_vessel_graph_projection()
             if self.patch_position_panel.display_location_checkbox.isChecked():
                 self._on_display_patch_location_changed(True)
             self.slice_viewer.volume_3d_view.mark_selected_dirty(
@@ -3133,6 +3263,177 @@ class PatchViewerWindow(QMainWindow):
         self._on_projection_mask_changed(selected_index)
         self._sync_volume_3d_sources()
 
+    def update_vessel_graph_layers(
+        self,
+        layers: Sequence[VesselGraphLayer],
+    ) -> None:
+        """Share main-session GraphML data while retaining patch-local settings."""
+        previous_settings = self._vessel_graph_settings
+        self._vessel_graph_layers = {layer.id: layer for layer in layers}
+        self._vessel_graph_settings = {}
+        for layer in layers:
+            existing = previous_settings.get(layer.id)
+            self._vessel_graph_settings[layer.id] = (
+                existing
+                if existing is not None
+                else VesselGraphDisplaySettings(
+                    visible=False,
+                    opacity=self.graph_state.opacity,
+                    node_size=self.graph_state.node_size,
+                    edge_thickness=self.graph_state.edge_thickness,
+                )
+            )
+        if self._active_vessel_graph_id not in self._vessel_graph_layers:
+            self._active_vessel_graph_id = None
+        self._rebuild_clipped_vessel_graphs()
+        self._refresh_vessel_graph_panel()
+        self._refresh_vessel_graph_projection()
+        self._sync_volume_3d_sources()
+
+    def _rebuild_clipped_vessel_graphs(self) -> None:
+        self._clipped_vessel_graphs = {}
+        bounds = self._source_patch_bounds
+        if bounds is None:
+            return
+        for layer in self._vessel_graph_layers.values():
+            if not layer.projection_safe:
+                continue
+            self._clipped_vessel_graphs[layer.id] = clip_vessel_graph_to_patch(
+                layer.data,
+                bounds,
+                self._patch_volume.affine,
+            )
+
+    def _active_vessel_graph_layer(self) -> VesselGraphLayer | None:
+        if self._active_vessel_graph_id is None:
+            return None
+        return self._vessel_graph_layers.get(self._active_vessel_graph_id)
+
+    def _active_vessel_graph_settings(
+        self,
+    ) -> VesselGraphDisplaySettings | None:
+        if self._active_vessel_graph_id is None:
+            return None
+        return self._vessel_graph_settings.get(self._active_vessel_graph_id)
+
+    def _refresh_vessel_graph_panel(self) -> None:
+        self.graph_panel.set_projected_graph_layers(
+            tuple(
+                (layer.id, layer.display_name)
+                for layer in self._vessel_graph_layers.values()
+            ),
+            self._active_vessel_graph_id,
+        )
+        layer = self._active_vessel_graph_layer()
+        settings = self._active_vessel_graph_settings()
+        if layer is None or settings is None:
+            self.graph_panel.set_projected_graph_state(
+                enabled=False,
+                available=False,
+                status=(
+                    "Select a GraphML layer to project."
+                    if self._vessel_graph_layers
+                    else "No GraphML layer loaded."
+                ),
+            )
+            return
+        if not layer.projection_safe:
+            self.graph_panel.set_projected_graph_state(
+                enabled=False,
+                available=False,
+                status="Spatial warning: projection is disabled for this layer.",
+                warning=True,
+            )
+        else:
+            clipped = self._clipped_vessel_graphs.get(layer.id)
+            self.graph_panel.set_projected_graph_state(
+                enabled=settings.visible,
+                available=bool(
+                    self.slice_viewer.enabled_projection_orientations()
+                ),
+                status=(
+                    f"{0 if clipped is None else len(clipped.polylines_world)} "
+                    "clipped paths."
+                ),
+            )
+
+    def _refresh_vessel_graph_projection(self) -> None:
+        layer = self._active_vessel_graph_layer()
+        settings = self._active_vessel_graph_settings()
+        geometry = (
+            None
+            if layer is None or not layer.projection_safe
+            else self._clipped_vessel_graphs.get(layer.id)
+        )
+        self.slice_viewer.set_vessel_graph_projection(geometry, settings)
+
+    def _on_vessel_graph_layer_changed(self, layer_id: object) -> None:
+        self._active_vessel_graph_id = (
+            layer_id if isinstance(layer_id, str) else None
+        )
+        self._refresh_vessel_graph_panel()
+        self._refresh_vessel_graph_projection()
+
+    def _on_vessel_graph_projection_toggle_requested(self) -> None:
+        settings = self._active_vessel_graph_settings()
+        if settings is None:
+            self.statusBar().showMessage(
+                "Select a GraphML layer before enabling projection."
+            )
+            return
+        try:
+            self.set_vessel_graph_display(
+                self._active_vessel_graph_id or "",
+                visible=not settings.visible,
+            )
+        except ValueError as exc:
+            self.statusBar().showMessage(str(exc))
+
+    def _sync_shared_graph_sizes_to_3d(self) -> None:
+        target = self.slice_viewer.volume_3d_view
+        self._syncing_patch_vessel_3d = True
+        try:
+            for layer_id in self._vessel_graph_layers:
+                render_settings = target.state.settings.get(layer_id)
+                if render_settings is None:
+                    continue
+                render_settings.set_node_size(self.graph_state.node_size)
+                render_settings.set_edge_thickness(
+                    self.graph_state.edge_thickness
+                )
+            selected = target.state.selected_source()
+            if selected is not None and selected.kind == "vessel_graph":
+                target.set_selected_node_size(self.graph_state.node_size)
+                target.set_selected_edge_thickness(
+                    self.graph_state.edge_thickness
+                )
+        finally:
+            self._syncing_patch_vessel_3d = False
+
+    def _on_patch_render3d_state_changed(self, status: object) -> None:
+        if self._syncing_patch_vessel_3d:
+            return
+        if not isinstance(status, dict):
+            return
+        layer_id = status.get("selected_source_id")
+        if not isinstance(layer_id, str) or layer_id not in self._vessel_graph_settings:
+            return
+        render_settings = self.slice_viewer.volume_3d_view.state.settings.get(
+            layer_id
+        )
+        if render_settings is None:
+            return
+        self.graph_state.set_node_size(render_settings.node_size)
+        self.graph_state.set_edge_thickness(render_settings.edge_thickness)
+        self.graph_panel.set_node_size(self.graph_state.node_size)
+        self.graph_panel.set_edge_thickness(self.graph_state.edge_thickness)
+        for settings in self._vessel_graph_settings.values():
+            settings.set_node_size(self.graph_state.node_size)
+            settings.set_edge_thickness(self.graph_state.edge_thickness)
+        self._sync_shared_graph_sizes_to_3d()
+        self.slice_viewer.refresh_graph_overlay()
+        self._refresh_vessel_graph_projection()
+
     def _sync_volume_3d_sources(self) -> None:
         sources = [
             Render3DSource(
@@ -3154,7 +3455,38 @@ class PatchViewerWindow(QMainWindow):
             )
             for segmentation_id, volume in self._projection_mask_layers.items()
         )
-        self.slice_viewer.volume_3d_view.set_sources(sources)
+        for layer_id, layer in self._vessel_graph_layers.items():
+            clipped = self._clipped_vessel_graphs.get(layer_id)
+            if clipped is None:
+                continue
+            sources.append(
+                Render3DSource(
+                    id=layer.id,
+                    display_name=layer.display_name,
+                    volume=None,
+                    kind="vessel_graph",
+                    vessel_graph=VesselGraphRenderGeometry(
+                        polylines_world=clipped.polylines_world,
+                        node_world_positions=clipped.node_world_positions,
+                        intercept_world_positions=(
+                            clipped.intercept_world_positions
+                        ),
+                    ),
+                )
+            )
+        self._syncing_patch_vessel_3d = True
+        try:
+            self.slice_viewer.volume_3d_view.set_sources(sources)
+            for layer_id, settings in self._vessel_graph_settings.items():
+                render_settings = (
+                    self.slice_viewer.volume_3d_view.state.settings.get(layer_id)
+                )
+                if render_settings is None:
+                    continue
+                render_settings.set_node_size(settings.node_size)
+                render_settings.set_edge_thickness(settings.edge_thickness)
+        finally:
+            self._syncing_patch_vessel_3d = False
 
     def _on_display_patch_location_changed(self, visible: bool) -> None:
         self.slice_viewer.volume_3d_view.set_locator_context(

--- a/src/mipview/ui/patch_window.py
+++ b/src/mipview/ui/patch_window.py
@@ -526,6 +526,17 @@ class PatchViewerWindow(QMainWindow):
             self.orientation_indicator_action_group.addAction(action)
             view_menu.addAction(action)
             self.orientation_indicator_actions[mode] = action
+        view_menu.addSeparator()
+        self.patch_extension_lines_action = QAction(
+            "Turn on/off patch indicator extension lines",
+            self,
+        )
+        self.patch_extension_lines_action.setCheckable(True)
+        self.patch_extension_lines_action.setChecked(True)
+        self.patch_extension_lines_action.toggled.connect(
+            self.slice_viewer.volume_3d_view.set_patch_extension_lines_visible
+        )
+        view_menu.addAction(self.patch_extension_lines_action)
 
         self.segmentation_menu = self.menuBar().addMenu("&Segmentation")
         self.unload_current_segmentation_action = QAction(

--- a/src/mipview/ui/volume_3d_panel.py
+++ b/src/mipview/ui/volume_3d_panel.py
@@ -5,11 +5,11 @@ from collections.abc import Sequence
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
-    QCheckBox,
     QColorDialog,
     QComboBox,
     QDoubleSpinBox,
     QFormLayout,
+    QGroupBox,
     QHBoxLayout,
     QLabel,
     QProgressBar,
@@ -27,8 +27,10 @@ class Volume3DPanel(CollapsibleGroupBox):
 
     activation_requested = Signal(bool)
     source_changed = Signal(object)
-    visibility_changed = Signal(bool)
     opacity_changed = Signal(float)
+    vessel_graph_node_size_changed = Signal(int)
+    vessel_graph_edge_thickness_changed = Signal(int)
+    vessel_graph_unload_requested = Signal(object)
     colour_changed = Signal(object)
     render_mode_changed = Signal(str)
     mask_changed = Signal(object)
@@ -36,9 +38,15 @@ class Volume3DPanel(CollapsibleGroupBox):
     update_requested = Signal()
     reset_camera_requested = Signal()
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        allow_vessel_graph_unload: bool = False,
+    ) -> None:
         super().__init__("3D Volume", parent)
         self._colour = (255, 255, 255)
+        self._source_kind: str | None = None
 
         form = QFormLayout(self)
         form.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
@@ -51,10 +59,6 @@ class Volume3DPanel(CollapsibleGroupBox):
         self.source_combo.currentIndexChanged.connect(
             lambda _index: self.source_changed.emit(self.source_combo.currentData())
         )
-
-        self.visible_checkbox = QCheckBox(self)
-        self.visible_checkbox.setChecked(True)
-        self.visible_checkbox.toggled.connect(self.visibility_changed.emit)
 
         self.opacity_slider = QSlider(Qt.Orientation.Horizontal, self)
         self.opacity_slider.setRange(0, 100)
@@ -103,10 +107,61 @@ class Volume3DPanel(CollapsibleGroupBox):
         self.status_label = QLabel("Activate the 3D view to begin.", self)
         self.status_label.setWordWrap(True)
 
+        self.vessel_graph_group = QGroupBox("Vessel Graph", self)
+        vessel_form = QFormLayout(self.vessel_graph_group)
+        vessel_form.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
+        self.vessel_graph_opacity_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.vessel_graph_group,
+        )
+        self.vessel_graph_opacity_slider.setRange(0, 100)
+        self.vessel_graph_opacity_slider.setValue(100)
+        self.vessel_graph_opacity_slider.valueChanged.connect(
+            lambda value: self.opacity_changed.emit(value / 100.0)
+        )
+        self.vessel_graph_node_size_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.vessel_graph_group,
+        )
+        self.vessel_graph_node_size_slider.setRange(1, 10)
+        self.vessel_graph_node_size_slider.setValue(4)
+        self.vessel_graph_node_size_slider.valueChanged.connect(
+            self.vessel_graph_node_size_changed.emit
+        )
+        self.vessel_graph_edge_thickness_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.vessel_graph_group,
+        )
+        self.vessel_graph_edge_thickness_slider.setRange(1, 10)
+        self.vessel_graph_edge_thickness_slider.setValue(2)
+        self.vessel_graph_edge_thickness_slider.valueChanged.connect(
+            self.vessel_graph_edge_thickness_changed.emit
+        )
+        vessel_form.addRow("Opacity:", self.vessel_graph_opacity_slider)
+        vessel_form.addRow("Node size:", self.vessel_graph_node_size_slider)
+        vessel_form.addRow(
+            "Edge thickness:",
+            self.vessel_graph_edge_thickness_slider,
+        )
+        if allow_vessel_graph_unload:
+            self.vessel_graph_unload_button = QPushButton(
+                "Unload Current Graph",
+                self.vessel_graph_group,
+            )
+            self.vessel_graph_unload_button.clicked.connect(
+                lambda: self.vessel_graph_unload_requested.emit(
+                    self.selected_source_id()
+                )
+            )
+            vessel_form.addRow(self.vessel_graph_unload_button)
+        else:
+            self.vessel_graph_unload_button = None
+        self.vessel_graph_group.setVisible(False)
+
+        self.opacity_label = QLabel("Opacity:", self)
         form.addRow(self.activation_button)
         form.addRow("3D Layer:", self.source_combo)
-        form.addRow("Visible:", self.visible_checkbox)
-        form.addRow("Opacity:", self.opacity_slider)
+        form.addRow(self.opacity_label, self.opacity_slider)
         form.addRow("Colour:", self.colour_button)
         form.addRow("Render mode:", self.render_mode_combo)
         form.addRow(self.mask_label, self.mask_combo)
@@ -114,6 +169,7 @@ class Volume3DPanel(CollapsibleGroupBox):
         form.addRow(action_row)
         form.addRow(self.progress_bar)
         form.addRow(self.status_label)
+        form.addRow(self.vessel_graph_group)
         self.set_render_controls_enabled(False)
         self._refresh_mask_availability()
 
@@ -171,14 +227,22 @@ class Volume3DPanel(CollapsibleGroupBox):
     def set_settings(self, settings: Render3DSettings) -> None:
         blockers: list[tuple[QWidget, bool]] = []
         for widget in (
-            self.visible_checkbox,
             self.opacity_slider,
+            self.vessel_graph_opacity_slider,
+            self.vessel_graph_node_size_slider,
+            self.vessel_graph_edge_thickness_slider,
             self.mask_combo,
             self.threshold_spinbox,
         ):
             blockers.append((widget, widget.blockSignals(True)))
-        self.visible_checkbox.setChecked(settings.visible)
         self.opacity_slider.setValue(int(round(settings.opacity * 100.0)))
+        self.vessel_graph_opacity_slider.setValue(
+            int(round(settings.opacity * 100.0))
+        )
+        self.vessel_graph_node_size_slider.setValue(settings.node_size)
+        self.vessel_graph_edge_thickness_slider.setValue(
+            settings.edge_thickness
+        )
         self.threshold_spinbox.setValue(settings.threshold)
         mask_index = self.mask_combo.findData(settings.mask_source_id)
         self.mask_combo.setCurrentIndex(max(mask_index, 0))
@@ -212,18 +276,38 @@ class Volume3DPanel(CollapsibleGroupBox):
     def set_render_controls_enabled(self, enabled: bool) -> None:
         for widget in (
             self.source_combo,
-            self.visible_checkbox,
             self.opacity_slider,
-            self.colour_button,
-            self.render_mode_combo,
-            self.mask_combo,
-            self.threshold_spinbox,
             self.update_button,
             self.reset_camera_button,
         ):
             widget.setEnabled(enabled)
+        is_graph = self._source_kind == "vessel_graph"
+        self.colour_button.setEnabled(enabled and not is_graph)
+        self.render_mode_combo.setEnabled(enabled and not is_graph)
+        self.mask_combo.setEnabled(enabled and not is_graph)
+        self.threshold_spinbox.setEnabled(enabled and not is_graph)
+        self.vessel_graph_opacity_slider.setEnabled(enabled and is_graph)
+        self.vessel_graph_node_size_slider.setEnabled(enabled and is_graph)
+        self.vessel_graph_edge_thickness_slider.setEnabled(
+            enabled and is_graph
+        )
+        if self.vessel_graph_unload_button is not None:
+            self.vessel_graph_unload_button.setEnabled(is_graph)
         self._refresh_threshold_availability()
         self._refresh_mask_availability()
+
+    def set_source_kind(self, source_kind: str | None) -> None:
+        self._source_kind = source_kind
+        is_graph = source_kind == "vessel_graph"
+        self.vessel_graph_group.setVisible(is_graph)
+        self.opacity_label.setVisible(not is_graph)
+        self.opacity_slider.setVisible(not is_graph)
+        self._refresh_threshold_availability()
+        self._refresh_mask_availability()
+        self.set_render_controls_enabled(
+            self.activation_button.isChecked()
+            and self.source_combo.currentIndex() >= 0
+        )
 
     def set_busy(self, busy: bool, message: str = "Preparing 3D layer…") -> None:
         self.progress_bar.setVisible(busy)
@@ -284,12 +368,17 @@ class Volume3DPanel(CollapsibleGroupBox):
         mode = self.render_mode_combo.currentText()
         active = self.activation_button.isChecked()
         self.threshold_spinbox.setEnabled(
-            active and mode in {"Translucent", "Isosurface", "Surface", "Points"}
+            active
+            and self._source_kind != "vessel_graph"
+            and mode in {"Translucent", "Isosurface", "Surface", "Points"}
         )
 
     def _refresh_mask_availability(self) -> None:
         mode = self.render_mode_combo.currentText()
-        visible = mode in {"MIP", "MinIP", "Surface", "Points"}
+        visible = (
+            self._source_kind != "vessel_graph"
+            and mode in {"MIP", "MinIP", "Surface", "Points"}
+        )
         self.mask_label.setVisible(visible)
         self.mask_combo.setVisible(visible)
         self.mask_combo.setEnabled(

--- a/src/mipview/ui/volume_3d_panel.py
+++ b/src/mipview/ui/volume_3d_panel.py
@@ -31,6 +31,7 @@ class Volume3DPanel(CollapsibleGroupBox):
     opacity_changed = Signal(float)
     colour_changed = Signal(object)
     render_mode_changed = Signal(str)
+    mask_changed = Signal(object)
     threshold_changed = Signal(float)
     update_requested = Signal()
     reset_camera_requested = Signal()
@@ -68,8 +69,15 @@ class Volume3DPanel(CollapsibleGroupBox):
 
         self.render_mode_combo = QComboBox(self)
         self.render_mode_combo.currentTextChanged.connect(
-            self.render_mode_changed.emit
+            self._on_render_mode_changed
         )
+
+        self.mask_combo = QComboBox(self)
+        self.mask_combo.addItem("---", None)
+        self.mask_combo.currentIndexChanged.connect(
+            lambda _index: self.mask_changed.emit(self.mask_combo.currentData())
+        )
+        self.mask_label = QLabel("Mask:", self)
 
         self.threshold_spinbox = QDoubleSpinBox(self)
         self.threshold_spinbox.setDecimals(4)
@@ -101,11 +109,13 @@ class Volume3DPanel(CollapsibleGroupBox):
         form.addRow("Opacity:", self.opacity_slider)
         form.addRow("Colour:", self.colour_button)
         form.addRow("Render mode:", self.render_mode_combo)
+        form.addRow(self.mask_label, self.mask_combo)
         form.addRow("Threshold:", self.threshold_spinbox)
         form.addRow(action_row)
         form.addRow(self.progress_bar)
         form.addRow(self.status_label)
         self.set_render_controls_enabled(False)
+        self._refresh_mask_availability()
 
     def set_sources(
         self,
@@ -139,18 +149,39 @@ class Volume3DPanel(CollapsibleGroupBox):
         self.render_mode_combo.setCurrentIndex(max(index, 0))
         self.render_mode_combo.blockSignals(was_blocked)
         self._refresh_threshold_availability()
+        self._refresh_mask_availability()
+
+    def set_masks(
+        self,
+        masks: Sequence[tuple[str, str]],
+        selected_mask_id: str | None,
+    ) -> None:
+        was_blocked = self.mask_combo.blockSignals(True)
+        self.mask_combo.clear()
+        self.mask_combo.addItem("---", None)
+        selected_index = 0
+        for source_id, display_name in masks:
+            self.mask_combo.addItem(display_name, source_id)
+            if source_id == selected_mask_id:
+                selected_index = self.mask_combo.count() - 1
+        self.mask_combo.setCurrentIndex(selected_index)
+        self.mask_combo.blockSignals(was_blocked)
+        self._refresh_mask_availability()
 
     def set_settings(self, settings: Render3DSettings) -> None:
         blockers: list[tuple[QWidget, bool]] = []
         for widget in (
             self.visible_checkbox,
             self.opacity_slider,
+            self.mask_combo,
             self.threshold_spinbox,
         ):
             blockers.append((widget, widget.blockSignals(True)))
         self.visible_checkbox.setChecked(settings.visible)
         self.opacity_slider.setValue(int(round(settings.opacity * 100.0)))
         self.threshold_spinbox.setValue(settings.threshold)
+        mask_index = self.mask_combo.findData(settings.mask_source_id)
+        self.mask_combo.setCurrentIndex(max(mask_index, 0))
         for widget, blocked in blockers:
             widget.blockSignals(blocked)
 
@@ -162,6 +193,7 @@ class Volume3DPanel(CollapsibleGroupBox):
             self.render_mode_combo.setCurrentIndex(index)
             self.render_mode_combo.blockSignals(was_blocked)
         self._refresh_threshold_availability()
+        self._refresh_mask_availability()
         self.set_status(
             "Update required." if settings.dirty else "3D layer ready."
         )
@@ -184,12 +216,14 @@ class Volume3DPanel(CollapsibleGroupBox):
             self.opacity_slider,
             self.colour_button,
             self.render_mode_combo,
+            self.mask_combo,
             self.threshold_spinbox,
             self.update_button,
             self.reset_camera_button,
         ):
             widget.setEnabled(enabled)
         self._refresh_threshold_availability()
+        self._refresh_mask_availability()
 
     def set_busy(self, busy: bool, message: str = "Preparing 3D layer…") -> None:
         self.progress_bar.setVisible(busy)
@@ -226,6 +260,11 @@ class Volume3DPanel(CollapsibleGroupBox):
         )
         self.activation_requested.emit(active)
 
+    def _on_render_mode_changed(self, render_mode: str) -> None:
+        self._refresh_threshold_availability()
+        self._refresh_mask_availability()
+        self.render_mode_changed.emit(render_mode)
+
     def _choose_colour(self) -> None:
         selected = QColorDialog.getColor(QColor(*self._colour), self, "3D Layer Colour")
         if not selected.isValid():
@@ -246,4 +285,15 @@ class Volume3DPanel(CollapsibleGroupBox):
         active = self.activation_button.isChecked()
         self.threshold_spinbox.setEnabled(
             active and mode in {"Translucent", "Isosurface", "Surface", "Points"}
+        )
+
+    def _refresh_mask_availability(self) -> None:
+        mode = self.render_mode_combo.currentText()
+        visible = mode in {"MIP", "MinIP", "Surface", "Points"}
+        self.mask_label.setVisible(visible)
+        self.mask_combo.setVisible(visible)
+        self.mask_combo.setEnabled(
+            visible
+            and self.activation_button.isChecked()
+            and self.source_combo.currentIndex() >= 0
         )

--- a/src/mipview/vessel_graph/__init__.py
+++ b/src/mipview/vessel_graph/__init__.py
@@ -1,0 +1,35 @@
+"""Read-only GraphML vessel graphs and their derived display geometry."""
+
+from mipview.vessel_graph.io import load_vessel_graphml
+from mipview.vessel_graph.model import (
+    PROJECTED_INTERCEPT_COLOR,
+    VESSEL_EDGE_COLOR,
+    VESSEL_NODE_COLOR,
+    ClippedVesselGraph,
+    ProjectedVesselGraphLayer,
+    VesselGraphData,
+    VesselGraphDisplaySettings,
+    VesselGraphLayer,
+    VesselGraphRenderGeometry,
+)
+from mipview.vessel_graph.spatial import (
+    clip_vessel_graph_to_patch,
+    full_vessel_graph_geometry,
+    project_clipped_vessel_graph,
+)
+
+__all__ = [
+    "PROJECTED_INTERCEPT_COLOR",
+    "VESSEL_EDGE_COLOR",
+    "VESSEL_NODE_COLOR",
+    "ClippedVesselGraph",
+    "ProjectedVesselGraphLayer",
+    "VesselGraphData",
+    "VesselGraphDisplaySettings",
+    "VesselGraphLayer",
+    "VesselGraphRenderGeometry",
+    "clip_vessel_graph_to_patch",
+    "full_vessel_graph_geometry",
+    "load_vessel_graphml",
+    "project_clipped_vessel_graph",
+]

--- a/src/mipview/vessel_graph/io.py
+++ b/src/mipview/vessel_graph/io.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+import xml.etree.ElementTree as ET
+from uuid import uuid4
+
+import numpy as np
+from nibabel.affines import apply_affine
+
+from mipview.io.nifti_io import NiftiLoadResult
+from mipview.vessel_graph.model import VesselGraphData, VesselGraphLayer
+
+
+WORLD_COORDINATE_TOLERANCE = 1.0e-4
+MAX_GRAPHML_BYTES = 512 * 1024 * 1024
+
+
+def load_vessel_graphml(
+    path: str | Path,
+    source_volume: NiftiLoadResult,
+) -> VesselGraphLayer:
+    """Load the supported SkelHub GraphML profile against one source NIfTI."""
+
+    graph_path = Path(path)
+    if not graph_path.is_file():
+        raise FileNotFoundError(f"GraphML file not found: {graph_path}")
+    if graph_path.suffix.lower() != ".graphml":
+        raise ValueError(f"Expected a .graphml file, got: {graph_path}")
+    if graph_path.stat().st_size > MAX_GRAPHML_BYTES:
+        raise ValueError(
+            f"GraphML file exceeds the {MAX_GRAPHML_BYTES // (1024 * 1024)} MB limit."
+        )
+    with graph_path.open("rb") as stream:
+        if b"<!DOCTYPE" in stream.read(4096).upper():
+            raise ValueError("GraphML files containing a DOCTYPE are not supported.")
+
+    original_shape, original_affine, original_to_loaded = _source_geometry(
+        source_volume
+    )
+    (
+        node_ids,
+        node_voxels,
+        node_world,
+        node_radii,
+        node_components,
+        edge_refs,
+        edge_centerlines,
+        edge_components,
+    ) = _parse_graphml(graph_path)
+
+    node_index = {node_id: index for index, node_id in enumerate(node_ids)}
+    edge_indices = np.empty((len(edge_refs), 2), dtype=np.int32)
+    for index, (source_id, target_id) in enumerate(edge_refs):
+        try:
+            edge_indices[index] = (
+                node_index[source_id],
+                node_index[target_id],
+            )
+        except KeyError as exc:
+            raise ValueError(
+                f"GraphML edge references missing node '{exc.args[0]}'."
+            ) from exc
+        if source_id == target_id:
+            raise ValueError(f"GraphML edge {index} is a self-edge.")
+
+    offsets = np.zeros(len(edge_centerlines) + 1, dtype=np.int64)
+    for index, centerline in enumerate(edge_centerlines):
+        offsets[index + 1] = offsets[index] + centerline.shape[0]
+    flattened_centerlines = (
+        np.concatenate(edge_centerlines, axis=0).astype(np.float64, copy=False)
+        if edge_centerlines
+        else np.empty((0, 3), dtype=np.float64)
+    )
+
+    warnings = _spatial_warnings(
+        node_voxels,
+        node_world,
+        flattened_centerlines,
+        original_shape,
+        original_affine,
+    )
+    data = VesselGraphData(
+        node_ids=tuple(node_ids),
+        node_source_voxels=np.asarray(node_voxels, dtype=np.float64),
+        node_world_positions=np.asarray(node_world, dtype=np.float64),
+        node_radii=np.asarray(node_radii, dtype=np.float32),
+        node_components=np.asarray(node_components, dtype=np.int64),
+        edge_node_indices=edge_indices,
+        edge_centerline_source_voxels=flattened_centerlines,
+        edge_centerline_offsets=offsets,
+        edge_components=np.asarray(edge_components, dtype=np.int64),
+        original_shape=original_shape,
+        original_affine=original_affine,
+        original_to_loaded_voxel_affine=original_to_loaded,
+        loaded_shape=tuple(int(value) for value in source_volume.shape[:3]),
+    )
+    return VesselGraphLayer(
+        id=f"graphml-{uuid4().hex}",
+        path=graph_path.resolve(strict=False),
+        data=data,
+        warnings=tuple(warnings),
+        projection_safe=not warnings,
+    )
+
+
+def _source_geometry(
+    volume: NiftiLoadResult,
+) -> tuple[tuple[int, int, int], np.ndarray, np.ndarray]:
+    original_shape_values = volume.original_shape or volume.shape
+    if len(original_shape_values) < 3:
+        raise ValueError("GraphML source image must be three-dimensional.")
+    original_shape = tuple(int(value) for value in original_shape_values[:3])
+    original_affine = np.asarray(
+        volume.original_affine
+        if volume.original_affine is not None
+        else volume.affine,
+        dtype=np.float64,
+    )
+    original_to_loaded = np.asarray(
+        volume.original_to_loaded_voxel_affine
+        if volume.original_to_loaded_voxel_affine is not None
+        else np.eye(4),
+        dtype=np.float64,
+    )
+    if original_affine.shape != (4, 4) or original_to_loaded.shape != (4, 4):
+        raise ValueError("GraphML source image affines must be 4x4.")
+    return original_shape, original_affine, original_to_loaded
+
+
+def _parse_graphml(
+    path: Path,
+) -> tuple[
+    list[str],
+    list[tuple[float, float, float]],
+    list[tuple[float, float, float]],
+    list[float],
+    list[int],
+    list[tuple[str, str]],
+    list[np.ndarray],
+    list[int],
+]:
+    key_names: dict[str, str] = {}
+    node_ids: list[str] = []
+    node_voxels: list[tuple[float, float, float]] = []
+    node_world: list[tuple[float, float, float]] = []
+    node_radii: list[float] = []
+    node_components: list[int] = []
+    edge_refs: list[tuple[str, str]] = []
+    edge_centerlines: list[np.ndarray] = []
+    edge_components: list[int] = []
+    seen_nodes: set[str] = set()
+    graph_default: str | None = None
+
+    try:
+        for event, element in ET.iterparse(path, events=("start", "end")):
+            tag = _local_name(element.tag)
+            if event == "start":
+                if tag == "key":
+                    key_id = element.attrib.get("id")
+                    name = element.attrib.get("attr.name")
+                    if key_id and name:
+                        key_names[key_id] = name
+                elif tag == "graph" and graph_default is None:
+                    graph_default = element.attrib.get("edgedefault")
+                continue
+
+            if tag == "node":
+                node_id = element.attrib.get("id")
+                if not node_id:
+                    raise ValueError("GraphML node is missing its id.")
+                if node_id in seen_nodes:
+                    raise ValueError(f"Duplicate GraphML node id '{node_id}'.")
+                seen_nodes.add(node_id)
+                values = _data_values(element, key_names)
+                node_ids.append(node_id)
+                node_voxels.append(
+                    _json_point(values.get("voxel_pos"), f"node {node_id} voxel_pos")
+                )
+                node_world.append(
+                    tuple(
+                        _finite_float(values.get(axis), f"node {node_id} {axis}")
+                        for axis in ("X", "Y", "Z")
+                    )
+                )
+                node_radii.append(
+                    math.nan
+                    if values.get("r") is None
+                    else _finite_float(values.get("r"), f"node {node_id} r")
+                )
+                node_components.append(
+                    _optional_integral(values.get("component_index"))
+                )
+                element.clear()
+            elif tag == "edge":
+                source_id = element.attrib.get("source")
+                target_id = element.attrib.get("target")
+                if not source_id or not target_id:
+                    raise ValueError("GraphML edge is missing source or target.")
+                values = _data_values(element, key_names)
+                centerline = _json_polyline(
+                    values.get("centerline_voxels"),
+                    f"edge {source_id}-{target_id} centerline_voxels",
+                )
+                declared_count = values.get("num_centerline_voxels")
+                if declared_count is not None and _integral(
+                    declared_count,
+                    f"edge {source_id}-{target_id} num_centerline_voxels",
+                ) != centerline.shape[0]:
+                    raise ValueError(
+                        f"GraphML edge {source_id}-{target_id} centerline count "
+                        "does not match its payload."
+                    )
+                edge_refs.append((source_id, target_id))
+                edge_centerlines.append(centerline)
+                edge_components.append(
+                    _optional_integral(values.get("component_index"))
+                )
+                element.clear()
+    except ET.ParseError as exc:
+        raise ValueError(f"Invalid GraphML XML: {exc}") from exc
+
+    if graph_default not in {None, "undirected"}:
+        raise ValueError("Only undirected vessel GraphML files are supported.")
+    if not node_ids:
+        raise ValueError("GraphML file contains no nodes.")
+    return (
+        node_ids,
+        node_voxels,
+        node_world,
+        node_radii,
+        node_components,
+        edge_refs,
+        edge_centerlines,
+        edge_components,
+    )
+
+
+def _data_values(element: ET.Element, key_names: dict[str, str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for child in element:
+        if _local_name(child.tag) != "data":
+            continue
+        key_id = child.attrib.get("key")
+        name = key_names.get(key_id or "")
+        if name is not None:
+            values[name] = "" if child.text is None else child.text.strip()
+    return values
+
+
+def _json_point(value: str | None, name: str) -> tuple[float, float, float]:
+    array = _json_array(value, name)
+    if array.shape != (3,):
+        raise ValueError(f"GraphML {name} must contain three coordinates.")
+    return tuple(float(item) for item in array)
+
+
+def _json_polyline(value: str | None, name: str) -> np.ndarray:
+    array = _json_array(value, name)
+    if array.ndim != 2 or array.shape[1] != 3 or array.shape[0] == 0:
+        raise ValueError(f"GraphML {name} must be a non-empty Nx3 array.")
+    return array
+
+
+def _json_array(value: str | None, name: str) -> np.ndarray:
+    if value is None:
+        raise ValueError(f"GraphML is missing required {name}.")
+    try:
+        parsed = json.loads(value)
+        array = np.asarray(parsed, dtype=np.float64)
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        raise ValueError(f"GraphML {name} is not a numeric JSON array.") from exc
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"GraphML {name} contains non-finite coordinates.")
+    return array
+
+
+def _finite_float(value: str | None, name: str) -> float:
+    if value is None:
+        raise ValueError(f"GraphML is missing required {name}.")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"GraphML {name} must be numeric.") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"GraphML {name} must be finite.")
+    return result
+
+
+def _optional_integral(value: str | None) -> int:
+    return -1 if value is None else _integral(value, "component_index")
+
+
+def _integral(value: str, name: str) -> int:
+    numeric = _finite_float(value, name)
+    rounded = int(round(numeric))
+    if not math.isclose(numeric, rounded, abs_tol=1.0e-9):
+        raise ValueError(f"GraphML {name} must be an integer value.")
+    return rounded
+
+
+def _spatial_warnings(
+    node_voxels: np.ndarray,
+    node_world: np.ndarray,
+    centerlines: np.ndarray,
+    shape: tuple[int, int, int],
+    affine: np.ndarray,
+) -> list[str]:
+    warnings: list[str] = []
+    shape_array = np.asarray(shape, dtype=np.float64)
+    node_array = np.asarray(node_voxels, dtype=np.float64)
+    world_array = np.asarray(node_world, dtype=np.float64)
+    if np.any(node_array < -0.5) or np.any(node_array > shape_array - 0.5):
+        warnings.append(
+            "Some GraphML node voxel positions fall outside the source image cells."
+        )
+    if centerlines.size and (
+        np.any(centerlines < 0.0)
+        or np.any(centerlines > shape_array - 1.0)
+    ):
+        warnings.append(
+            "Some GraphML centerline voxels fall outside the source image dimensions."
+        )
+    expected_world = np.asarray(apply_affine(affine, node_array), dtype=np.float64)
+    maximum_error = float(np.max(np.linalg.norm(expected_world - world_array, axis=1)))
+    if maximum_error > WORLD_COORDINATE_TOLERANCE:
+        warnings.append(
+            "GraphML X/Y/Z coordinates disagree with the loaded source NIfTI "
+            f"affine (maximum error {maximum_error:.6g})."
+        )
+    return warnings
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]

--- a/src/mipview/vessel_graph/model.py
+++ b/src/mipview/vessel_graph/model.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+from mipview.viewer.slice_geometry import Orientation
+
+
+VESSEL_NODE_COLOR = (255, 0, 0)
+VESSEL_EDGE_COLOR = (57, 255, 20)
+PROJECTED_INTERCEPT_COLOR = (30, 144, 255)
+
+
+@dataclass(frozen=True)
+class VesselGraphData:
+    """Immutable full-volume vessel graph loaded from GraphML."""
+
+    node_ids: tuple[str, ...]
+    node_source_voxels: np.ndarray
+    node_world_positions: np.ndarray
+    node_radii: np.ndarray
+    node_components: np.ndarray
+    edge_node_indices: np.ndarray
+    edge_centerline_source_voxels: np.ndarray
+    edge_centerline_offsets: np.ndarray
+    edge_components: np.ndarray
+    original_shape: tuple[int, int, int]
+    original_affine: np.ndarray
+    original_to_loaded_voxel_affine: np.ndarray
+    loaded_shape: tuple[int, int, int]
+
+    @property
+    def node_count(self) -> int:
+        return int(self.node_world_positions.shape[0])
+
+    @property
+    def edge_count(self) -> int:
+        return int(self.edge_node_indices.shape[0])
+
+    @property
+    def centerline_point_count(self) -> int:
+        return int(self.edge_centerline_source_voxels.shape[0])
+
+    @property
+    def component_count(self) -> int:
+        components = np.concatenate(
+            (
+                self.node_components[self.node_components >= 0],
+                self.edge_components[self.edge_components >= 0],
+            )
+        )
+        return int(np.unique(components).size) if components.size else 0
+
+    def edge_centerline(self, edge_index: int) -> np.ndarray:
+        start = int(self.edge_centerline_offsets[edge_index])
+        end = int(self.edge_centerline_offsets[edge_index + 1])
+        return self.edge_centerline_source_voxels[start:end]
+
+
+@dataclass
+class VesselGraphDisplaySettings:
+    """One viewer's display settings for a loaded GraphML layer."""
+
+    visible: bool = False
+    opacity: float = 1.0
+    node_size: int = 4
+    edge_thickness: int = 2
+
+    def set_opacity(self, opacity: float) -> None:
+        self.opacity = min(max(float(opacity), 0.0), 1.0)
+
+    def set_node_size(self, node_size: int) -> None:
+        self.node_size = min(max(int(node_size), 1), 10)
+
+    def set_edge_thickness(self, edge_thickness: int) -> None:
+        self.edge_thickness = min(max(int(edge_thickness), 1), 10)
+
+
+@dataclass
+class VesselGraphLayer:
+    """Main-session GraphML layer with immutable data and main-view settings."""
+
+    id: str
+    path: Path
+    data: VesselGraphData
+    warnings: tuple[str, ...] = ()
+    projection_safe: bool = True
+    settings: VesselGraphDisplaySettings = field(
+        default_factory=VesselGraphDisplaySettings
+    )
+
+    @property
+    def display_name(self) -> str:
+        prefix = "⚠ " if self.warnings else ""
+        return f"{prefix}{self.path.name}"
+
+    def status(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "path": str(self.path),
+            "display_name": self.display_name,
+            "node_count": self.data.node_count,
+            "edge_count": self.data.edge_count,
+            "centerline_point_count": self.data.centerline_point_count,
+            "component_count": self.data.component_count,
+            "projection_safe": self.projection_safe,
+            "warnings": list(self.warnings),
+            "visible": self.settings.visible,
+            "opacity": self.settings.opacity,
+            "node_size": self.settings.node_size,
+            "edge_thickness": self.settings.edge_thickness,
+        }
+
+
+@dataclass(frozen=True)
+class ClippedVesselGraph:
+    """Patch-clipped vessel geometry in patch-local loaded voxel and world space."""
+
+    patch_shape: tuple[int, int, int]
+    patch_affine: np.ndarray
+    polylines_patch_voxel: tuple[np.ndarray, ...]
+    polylines_world: tuple[np.ndarray, ...]
+    node_patch_voxels: np.ndarray
+    node_world_positions: np.ndarray
+    intercept_patch_voxels: np.ndarray
+    intercept_world_positions: np.ndarray
+
+    @property
+    def is_empty(self) -> bool:
+        return (
+            not self.polylines_patch_voxel
+            and self.node_patch_voxels.size == 0
+            and self.intercept_patch_voxels.size == 0
+        )
+
+
+@dataclass(frozen=True)
+class ProjectedVesselGraphLayer:
+    """Read-only 2D projection derived from one patch-clipped GraphML layer."""
+
+    orientation: Orientation
+    plane_shape: tuple[int, int]
+    polylines: tuple[np.ndarray, ...]
+    node_positions: np.ndarray
+    intercept_positions: np.ndarray
+
+
+@dataclass(frozen=True)
+class VesselGraphRenderGeometry:
+    """World-space data consumed by one standalone 3D graph layer."""
+
+    polylines_world: tuple[np.ndarray, ...]
+    node_world_positions: np.ndarray
+    intercept_world_positions: np.ndarray = field(
+        default_factory=lambda: np.empty((0, 3), dtype=np.float64)
+    )

--- a/src/mipview/vessel_graph/spatial.py
+++ b/src/mipview/vessel_graph/spatial.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import numpy as np
+from nibabel.affines import apply_affine
+
+from mipview.patch.selector import PatchBounds
+from mipview.vessel_graph.model import (
+    ClippedVesselGraph,
+    ProjectedVesselGraphLayer,
+    VesselGraphData,
+)
+from mipview.viewer.oriented_volume import OrientedVolume
+from mipview.viewer.slice_geometry import (
+    Orientation,
+    plane_definition_for_orientation,
+    plane_shape_for_orientation,
+)
+
+
+def full_vessel_graph_geometry(
+    graph: VesselGraphData,
+    *,
+    use_centerlines: bool = True,
+) -> tuple[tuple[np.ndarray, ...], np.ndarray]:
+    """Return full graph world-space polylines and true node positions."""
+    paths: list[np.ndarray] = []
+    for edge_index, (source_index, target_index) in enumerate(
+        graph.edge_node_indices
+    ):
+        source = graph.node_world_positions[int(source_index)]
+        target = graph.node_world_positions[int(target_index)]
+        if use_centerlines:
+            centerline = graph.edge_centerline(edge_index)
+            centerline_world = apply_affine(graph.original_affine, centerline)
+            path = np.vstack((source, centerline_world, target))
+        else:
+            path = np.vstack((source, target))
+        paths.append(_drop_adjacent_duplicates(path))
+    return tuple(paths), np.asarray(graph.node_world_positions, dtype=np.float64)
+
+
+def clip_vessel_graph_to_patch(
+    graph: VesselGraphData,
+    bounds: PatchBounds,
+    patch_affine: np.ndarray,
+) -> ClippedVesselGraph:
+    """Clip graph paths to patch voxel-cell bounds and mark boundary intercepts."""
+    starts = np.asarray(
+        (bounds.x_start, bounds.y_start, bounds.z_start),
+        dtype=np.float64,
+    )
+    lower = starts - 0.5
+    upper = np.asarray(
+        (bounds.x_end, bounds.y_end, bounds.z_end),
+        dtype=np.float64,
+    ) - 0.5
+
+    node_loaded = np.asarray(
+        apply_affine(
+            graph.original_to_loaded_voxel_affine,
+            graph.node_source_voxels,
+        ),
+        dtype=np.float64,
+    )
+    node_inside = np.all(node_loaded >= lower, axis=1) & np.all(
+        node_loaded <= upper,
+        axis=1,
+    )
+    inside_loaded = node_loaded[node_inside]
+    inside_patch = inside_loaded - starts
+    inside_world = np.asarray(
+        apply_affine(patch_affine, inside_patch),
+        dtype=np.float64,
+    )
+
+    clipped_patch_paths: list[np.ndarray] = []
+    clipped_world_paths: list[np.ndarray] = []
+    intercept_patch_points: list[np.ndarray] = []
+    for edge_index, (source_index, target_index) in enumerate(
+        graph.edge_node_indices
+    ):
+        source_original = graph.node_source_voxels[int(source_index)]
+        target_original = graph.node_source_voxels[int(target_index)]
+        original_path = np.vstack(
+            (
+                source_original,
+                graph.edge_centerline(edge_index),
+                target_original,
+            )
+        )
+        loaded_path = np.asarray(
+            apply_affine(graph.original_to_loaded_voxel_affine, original_path),
+            dtype=np.float64,
+        )
+        for clipped, intercepts in _clip_polyline_to_box(loaded_path, lower, upper):
+            patch_path = clipped - starts
+            clipped_patch_paths.append(patch_path)
+            clipped_world_paths.append(
+                np.asarray(apply_affine(patch_affine, patch_path), dtype=np.float64)
+            )
+            intercept_patch_points.extend(point - starts for point in intercepts)
+
+    intercept_patch = _unique_points(intercept_patch_points)
+    intercept_world = np.asarray(
+        apply_affine(patch_affine, intercept_patch),
+        dtype=np.float64,
+    )
+    return ClippedVesselGraph(
+        patch_shape=(
+            bounds.x_end - bounds.x_start,
+            bounds.y_end - bounds.y_start,
+            bounds.z_end - bounds.z_start,
+        ),
+        patch_affine=np.asarray(patch_affine, dtype=np.float64),
+        polylines_patch_voxel=tuple(clipped_patch_paths),
+        polylines_world=tuple(clipped_world_paths),
+        node_patch_voxels=inside_patch,
+        node_world_positions=inside_world,
+        intercept_patch_voxels=intercept_patch,
+        intercept_world_positions=intercept_world,
+    )
+
+
+def project_clipped_vessel_graph(
+    clipped: ClippedVesselGraph,
+    oriented_volume: OrientedVolume,
+    orientation: Orientation,
+) -> ProjectedVesselGraphLayer:
+    """Project known 3D graph geometry orthographically into a patch plane."""
+    return ProjectedVesselGraphLayer(
+        orientation=orientation,
+        plane_shape=plane_shape_for_orientation(
+            oriented_volume.display_shape,
+            orientation,
+        ),
+        polylines=tuple(
+            _project_points(path, oriented_volume, orientation)
+            for path in clipped.polylines_patch_voxel
+        ),
+        node_positions=_project_points(
+            clipped.node_patch_voxels,
+            oriented_volume,
+            orientation,
+        ),
+        intercept_positions=_project_points(
+            clipped.intercept_patch_voxels,
+            oriented_volume,
+            orientation,
+        ),
+    )
+
+
+def _project_points(
+    source_points: np.ndarray,
+    oriented_volume: OrientedVolume,
+    orientation: Orientation,
+) -> np.ndarray:
+    points = np.asarray(source_points, dtype=np.float64)
+    if points.size == 0:
+        return np.empty((0, 2), dtype=np.float64)
+    display_points = np.asarray(
+        apply_affine(oriented_volume.source_to_display_affine, points),
+        dtype=np.float64,
+    )
+    definition = plane_definition_for_orientation(orientation)
+    horizontal = display_points[:, definition.horizontal_axis]
+    vertical = display_points[:, definition.vertical_axis]
+    if definition.horizontal_flipped:
+        horizontal = (
+            oriented_volume.display_shape[definition.horizontal_axis]
+            - 1
+            - horizontal
+        )
+    if definition.vertical_flipped:
+        vertical = (
+            oriented_volume.display_shape[definition.vertical_axis]
+            - 1
+            - vertical
+        )
+    return np.column_stack((horizontal, vertical))
+
+
+def _clip_polyline_to_box(
+    path: np.ndarray,
+    lower: np.ndarray,
+    upper: np.ndarray,
+) -> list[tuple[np.ndarray, tuple[np.ndarray, ...]]]:
+    results: list[tuple[np.ndarray, tuple[np.ndarray, ...]]] = []
+    current: list[np.ndarray] = []
+    current_intercepts: list[np.ndarray] = []
+    for start, end in zip(path[:-1], path[1:]):
+        clipped = _clip_segment_to_box(start, end, lower, upper)
+        if clipped is None:
+            if len(current) >= 2:
+                results.append(
+                    (_drop_adjacent_duplicates(np.asarray(current)), tuple(current_intercepts))
+                )
+            current = []
+            current_intercepts = []
+            continue
+        first, second, first_intercept, second_intercept = clipped
+        if not current or not np.allclose(current[-1], first, atol=1.0e-9, rtol=0.0):
+            if len(current) >= 2:
+                results.append(
+                    (_drop_adjacent_duplicates(np.asarray(current)), tuple(current_intercepts))
+                )
+            current = [first]
+            current_intercepts = []
+        current.append(second)
+        if first_intercept:
+            current_intercepts.append(first)
+        if second_intercept:
+            current_intercepts.append(second)
+    if len(current) >= 2:
+        results.append(
+            (_drop_adjacent_duplicates(np.asarray(current)), tuple(current_intercepts))
+        )
+    return results
+
+
+def _clip_segment_to_box(
+    start: np.ndarray,
+    end: np.ndarray,
+    lower: np.ndarray,
+    upper: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, bool, bool] | None:
+    delta = end - start
+    t_min = 0.0
+    t_max = 1.0
+    for axis in range(3):
+        if abs(float(delta[axis])) <= 1.0e-12:
+            if start[axis] < lower[axis] or start[axis] > upper[axis]:
+                return None
+            continue
+        first = (lower[axis] - start[axis]) / delta[axis]
+        second = (upper[axis] - start[axis]) / delta[axis]
+        entering = min(first, second)
+        exiting = max(first, second)
+        t_min = max(t_min, float(entering))
+        t_max = min(t_max, float(exiting))
+        if t_min > t_max:
+            return None
+    clipped_start = start + delta * t_min
+    clipped_end = start + delta * t_max
+    return (
+        clipped_start,
+        clipped_end,
+        t_min > 1.0e-9,
+        t_max < 1.0 - 1.0e-9,
+    )
+
+
+def _drop_adjacent_duplicates(points: np.ndarray) -> np.ndarray:
+    array = np.asarray(points, dtype=np.float64)
+    if array.shape[0] <= 1:
+        return array
+    keep = np.ones(array.shape[0], dtype=bool)
+    keep[1:] = np.any(np.abs(np.diff(array, axis=0)) > 1.0e-9, axis=1)
+    return array[keep]
+
+
+def _unique_points(points: list[np.ndarray]) -> np.ndarray:
+    if not points:
+        return np.empty((0, 3), dtype=np.float64)
+    unique: list[np.ndarray] = []
+    for point in points:
+        if not any(np.allclose(point, item, atol=1.0e-7, rtol=0.0) for item in unique):
+            unique.append(np.asarray(point, dtype=np.float64))
+    return np.asarray(unique, dtype=np.float64)

--- a/src/mipview/viewer/orientation_indicator.py
+++ b/src/mipview/viewer/orientation_indicator.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Literal
+
+
+ORIENTATION_INDICATOR_LABELS = "labels"
+ORIENTATION_INDICATOR_WIDGET = "widget"
+ORIENTATION_INDICATOR_OFF = "off"
+ORIENTATION_INDICATOR_MODES = (
+    ORIENTATION_INDICATOR_LABELS,
+    ORIENTATION_INDICATOR_WIDGET,
+    ORIENTATION_INDICATOR_OFF,
+)
+ORIENTATION_AXIS_COLOURS = {
+    "L": "#ef5350",
+    "R": "#ef5350",
+    "A": "#66bb6a",
+    "P": "#66bb6a",
+    "I": "#42a5f5",
+    "S": "#42a5f5",
+}
+
+OrientationIndicatorMode = Literal["labels", "widget", "off"]
+
+
+def normalize_orientation_indicator_mode(mode: str) -> OrientationIndicatorMode:
+    normalized = str(mode).strip().lower()
+    if normalized not in ORIENTATION_INDICATOR_MODES:
+        raise ValueError(
+            "Unknown orientation indicator mode "
+            f"{mode!r}; expected one of {', '.join(ORIENTATION_INDICATOR_MODES)}."
+        )
+    return normalized  # type: ignore[return-value]
+
+
+def orientation_axis_colour(label: str) -> str:
+    try:
+        return ORIENTATION_AXIS_COLOURS[label.upper()]
+    except KeyError as exc:
+        raise ValueError(f"Unknown anatomical orientation label: {label!r}.") from exc

--- a/src/mipview/viewer/render_3d_preparation.py
+++ b/src/mipview/viewer/render_3d_preparation.py
@@ -28,6 +28,7 @@ class PreparedRender3D:
     prepared_shape: tuple[int, int, int]
     stride: tuple[int, int, int]
     source_range: tuple[float, float]
+    mask_applied: bool = False
 
 
 def prepare_render(
@@ -36,6 +37,7 @@ def prepare_render(
     kind: str,
     render_mode: str,
     threshold: float,
+    mask_volume: NiftiLoadResult | None = None,
     maximum_dimension: int = MAX_VOLUME_DIMENSION,
 ) -> PreparedRender3D:
     """Prepare a bounded-size CPU representation for later GPU upload."""
@@ -49,6 +51,13 @@ def prepare_render(
     stride = (stride_value, stride_value, stride_value)
     sampled = source[::stride_value, ::stride_value, ::stride_value]
     prepared_shape = tuple(int(value) for value in sampled.shape)
+    sampled_mask = _sample_render_mask(
+        volume,
+        mask_volume,
+        stride_value=stride_value,
+        kind=kind,
+        render_mode=render_mode,
+    )
 
     statistics_stride = max(1, math.ceil(max(sampled.shape) / 128))
     statistics_sample = sampled[
@@ -56,7 +65,14 @@ def prepare_render(
         ::statistics_stride,
         ::statistics_stride,
     ]
-    finite = statistics_sample[np.isfinite(statistics_sample)]
+    statistics_valid = np.isfinite(statistics_sample)
+    if sampled_mask is not None:
+        statistics_valid &= sampled_mask[
+            ::statistics_stride,
+            ::statistics_stride,
+            ::statistics_stride,
+        ]
+    finite = statistics_sample[statistics_valid]
     if finite.size:
         source_range = (float(np.min(finite)), float(np.max(finite)))
     else:
@@ -65,6 +81,12 @@ def prepare_render(
     if kind == "image":
         source_range = _robust_image_range(finite, source_range)
         normalized = _normalize_to_uint8(sampled, source_range)
+        if sampled_mask is not None:
+            normalized = _apply_image_render_mask(
+                normalized,
+                sampled_mask,
+                render_mode,
+            )
         # VisPy Volume expects data ordered as z, y, x.
         texture_data = np.ascontiguousarray(normalized.transpose(2, 1, 0))
         scale = np.diag(
@@ -80,9 +102,12 @@ def prepare_render(
             prepared_shape=prepared_shape,
             stride=stride,
             source_range=source_range,
+            mask_applied=sampled_mask is not None,
         )
 
     foreground = np.asarray(np.isfinite(sampled) & (sampled > float(threshold)))
+    if sampled_mask is not None:
+        foreground &= sampled_mask
     if render_mode == "Points":
         points = np.argwhere(foreground)
         if points.shape[0] > MAX_POINT_COUNT:
@@ -103,6 +128,7 @@ def prepare_render(
             prepared_shape=prepared_shape,
             stride=stride,
             source_range=source_range,
+            mask_applied=sampled_mask is not None,
         )
 
     if not np.any(foreground):
@@ -141,6 +167,7 @@ def prepare_render(
         prepared_shape=prepared_shape,
         stride=stride,
         source_range=source_range,
+        mask_applied=sampled_mask is not None,
     )
 
 
@@ -158,6 +185,93 @@ def patch_box_world_segments(
         dtype=np.float64,
     ) - 0.5
     return box_world_segments(starts, ends, affine)
+
+
+def patch_box_extension_world_segments(
+    bounds: PatchBounds,
+    source_shape: tuple[int, int, int],
+    affine: np.ndarray,
+) -> np.ndarray:
+    """Return dashed extensions of patch edges to the source-volume boundary."""
+    shape = np.asarray(source_shape, dtype=np.int64)
+    if shape.shape != (3,) or np.any(shape <= 0):
+        raise ValueError("Patch extension source shape must contain three positive sizes.")
+
+    patch_starts = np.asarray(
+        [bounds.x_start, bounds.y_start, bounds.z_start],
+        dtype=np.float64,
+    ) - 0.5
+    patch_ends = np.asarray(
+        [bounds.x_end, bounds.y_end, bounds.z_end],
+        dtype=np.float64,
+    ) - 0.5
+    source_starts = np.full(3, -0.5, dtype=np.float64)
+    source_ends = shape.astype(np.float64) - 0.5
+    if np.any(patch_starts < source_starts) or np.any(
+        patch_ends > source_ends
+    ):
+        raise ValueError("Patch bounds must stay inside the extension source volume.")
+
+    transform = np.asarray(affine, dtype=np.float64)
+    if transform.shape != (4, 4):
+        raise ValueError(f"Patch extension affine must be 4x4, got {transform.shape}.")
+
+    source_world = np.asarray(
+        apply_affine(
+            transform,
+            np.asarray([source_starts, source_ends]),
+        ),
+        dtype=np.float64,
+    )
+    source_diagonal = float(np.linalg.norm(source_world[1] - source_world[0]))
+    dash_length = max(source_diagonal / 80.0, np.finfo(np.float32).eps)
+    gap_length = dash_length * 0.8
+    dashed_segments: list[np.ndarray] = []
+
+    for axis in range(3):
+        fixed_axes = tuple(index for index in range(3) if index != axis)
+        for first_value in (
+            patch_starts[fixed_axes[0]],
+            patch_ends[fixed_axes[0]],
+        ):
+            for second_value in (
+                patch_starts[fixed_axes[1]],
+                patch_ends[fixed_axes[1]],
+            ):
+                patch_start = patch_starts.copy()
+                patch_end = patch_ends.copy()
+                patch_start[fixed_axes[0]] = first_value
+                patch_start[fixed_axes[1]] = second_value
+                patch_end[fixed_axes[0]] = first_value
+                patch_end[fixed_axes[1]] = second_value
+
+                lower_source = patch_start.copy()
+                lower_source[axis] = source_starts[axis]
+                upper_source = patch_end.copy()
+                upper_source[axis] = source_ends[axis]
+                for start_voxel, end_voxel in (
+                    (patch_start, lower_source),
+                    (patch_end, upper_source),
+                ):
+                    world_endpoints = np.asarray(
+                        apply_affine(
+                            transform,
+                            np.asarray([start_voxel, end_voxel]),
+                        ),
+                        dtype=np.float64,
+                    )
+                    dashed_segments.extend(
+                        _dashed_line_world_segments(
+                            world_endpoints[0],
+                            world_endpoints[1],
+                            dash_length=dash_length,
+                            gap_length=gap_length,
+                        )
+                    )
+
+    if not dashed_segments:
+        return np.empty((0, 3), dtype=np.float32)
+    return np.asarray(dashed_segments, dtype=np.float32).reshape(-1, 3)
 
 
 def source_box_world_segments(
@@ -210,7 +324,7 @@ def orientation_label_world_positions(
         dtype=np.float64,
     )
     minimum_padding = max(float(np.linalg.norm(span)) * 0.002, 1.0e-3)
-    padding = np.maximum(span * 0.04, minimum_padding)
+    padding = np.maximum(span * 0.10, minimum_padding)
     positions = np.repeat(midpoints[None, :], 6, axis=0)
     positions[0, 0] = limits[0][0] - padding[0]
     positions[1, 0] = limits[0][1] + padding[0]
@@ -290,6 +404,108 @@ def _normalize_to_uint8(
     scaled = (np.asarray(data, dtype=np.float32) - minimum) / (maximum - minimum)
     scaled[~np.isfinite(scaled)] = 0.0
     return np.asarray(np.clip(scaled * 255.0, 0.0, 255.0), dtype=np.uint8)
+
+
+def _sample_render_mask(
+    volume: NiftiLoadResult,
+    mask_volume: NiftiLoadResult | None,
+    *,
+    stride_value: int,
+    kind: str,
+    render_mode: str,
+) -> np.ndarray | None:
+    if mask_volume is None:
+        return None
+    supported = (
+        kind == "image"
+        and render_mode in {"MIP", "MinIP"}
+        or kind == "segmentation"
+        and render_mode in {"Surface", "Points"}
+    )
+    if not supported:
+        raise ValueError(
+            f"3D masking is not supported for {kind} mode {render_mode!r}."
+        )
+    mask_data = np.asarray(mask_volume.data)
+    if mask_data.ndim != 3:
+        raise ValueError(f"3D render mask must be 3D, got {mask_data.ndim}D.")
+    if volume.shape != mask_volume.shape:
+        raise ValueError(
+            "3D render mask shape does not match the selected layer: "
+            f"layer={volume.shape}, mask={mask_volume.shape}."
+        )
+    if (
+        np.asarray(volume.affine).shape != (4, 4)
+        or np.asarray(mask_volume.affine).shape != (4, 4)
+        or not np.allclose(
+            volume.affine,
+            mask_volume.affine,
+            atol=1.0e-4,
+            rtol=0.0,
+        )
+    ):
+        raise ValueError(
+            "3D render mask affine does not match the selected layer."
+        )
+    sampled = mask_data[::stride_value, ::stride_value, ::stride_value]
+    return np.asarray(np.isfinite(sampled) & (sampled != 0))
+
+
+def _apply_image_render_mask(
+    normalized: np.ndarray,
+    sampled_mask: np.ndarray,
+    render_mode: str,
+) -> np.ndarray:
+    # Reserve one end of the scalar range as a transparent sentinel. For MinIP,
+    # the sentinel must be greater than every included value so it cannot win a
+    # ray minimum; MIP uses the inverse arrangement.
+    scaled = (
+        np.asarray(normalized, dtype=np.uint16) * np.uint16(254)
+    ) // np.uint16(255)
+    if render_mode == "MIP":
+        included = np.asarray(scaled + 1, dtype=np.uint8)
+        return np.where(sampled_mask, included, 0).astype(np.uint8, copy=False)
+    if render_mode == "MinIP":
+        included = np.asarray(scaled, dtype=np.uint8)
+        return np.where(sampled_mask, included, 255).astype(np.uint8, copy=False)
+    raise ValueError(f"Unsupported masked image render mode: {render_mode!r}.")
+
+
+def _dashed_line_world_segments(
+    start: np.ndarray,
+    end: np.ndarray,
+    *,
+    dash_length: float,
+    gap_length: float,
+) -> list[np.ndarray]:
+    delta = np.asarray(end, dtype=np.float64) - np.asarray(
+        start,
+        dtype=np.float64,
+    )
+    length = float(np.linalg.norm(delta))
+    if length <= np.finfo(np.float32).eps:
+        return []
+    direction = delta / length
+    segments: list[np.ndarray] = []
+    distance = 0.0
+    while distance < length:
+        dash_end = min(distance + dash_length, length)
+        segments.extend(
+            (
+                np.asarray(start, dtype=np.float64) + direction * distance,
+                np.asarray(start, dtype=np.float64) + direction * dash_end,
+            )
+        )
+        distance += dash_length + gap_length
+    if not np.allclose(segments[-1], end):
+        final_start = max(0.0, length - min(dash_length, length) * 0.5)
+        segments.extend(
+            (
+                np.asarray(start, dtype=np.float64) + direction * final_start,
+                np.asarray(end, dtype=np.float64),
+            )
+        )
+    return segments
 
 
 def _robust_image_range(

--- a/src/mipview/viewer/render_3d_preparation.py
+++ b/src/mipview/viewer/render_3d_preparation.py
@@ -169,6 +169,61 @@ def source_box_world_segments(
     return box_world_segments(starts, ends, affine)
 
 
+def cursor_world_position(
+    voxel: tuple[int, int, int],
+    shape: tuple[int, int, int],
+    affine: np.ndarray,
+) -> np.ndarray:
+    """Map one validated source-voxel cursor position into RAS world space."""
+    voxel_position = np.asarray(voxel, dtype=np.float64)
+    volume_shape = np.asarray(shape, dtype=np.int64)
+    if voxel_position.shape != (3,):
+        raise ValueError("3D cursor position must contain exactly three coordinates.")
+    if volume_shape.shape != (3,) or np.any(volume_shape <= 0):
+        raise ValueError("3D cursor volume shape must contain three positive sizes.")
+    if np.any(voxel_position < 0) or np.any(voxel_position >= volume_shape):
+        raise ValueError(
+            f"3D cursor {tuple(voxel)} is outside volume shape {tuple(shape)}."
+        )
+
+    transform = np.asarray(affine, dtype=np.float64)
+    if transform.shape != (4, 4):
+        raise ValueError(f"3D cursor affine must be 4x4, got {transform.shape}.")
+    return np.asarray(
+        apply_affine(transform, voxel_position),
+        dtype=np.float32,
+    )
+
+
+def orientation_label_world_positions(
+    shape: tuple[int, int, int],
+    affine: np.ndarray,
+) -> tuple[tuple[str, ...], np.ndarray]:
+    """Place L/R, P/A, and I/S labels around the volume in RAS world space."""
+    limits = _world_limits_for_shape(shape, affine)
+    midpoints = np.asarray(
+        [(minimum + maximum) / 2.0 for minimum, maximum in limits],
+        dtype=np.float64,
+    )
+    span = np.asarray(
+        [maximum - minimum for minimum, maximum in limits],
+        dtype=np.float64,
+    )
+    minimum_padding = max(float(np.linalg.norm(span)) * 0.002, 1.0e-3)
+    padding = np.maximum(span * 0.04, minimum_padding)
+    positions = np.repeat(midpoints[None, :], 6, axis=0)
+    positions[0, 0] = limits[0][0] - padding[0]
+    positions[1, 0] = limits[0][1] + padding[0]
+    positions[2, 1] = limits[1][0] - padding[1]
+    positions[3, 1] = limits[1][1] + padding[1]
+    positions[4, 2] = limits[2][0] - padding[2]
+    positions[5, 2] = limits[2][1] + padding[2]
+    return ("L", "R", "P", "A", "I", "S"), np.asarray(
+        positions,
+        dtype=np.float32,
+    )
+
+
 def box_world_segments(
     starts: np.ndarray,
     ends: np.ndarray,
@@ -205,6 +260,23 @@ def box_world_segments(
     return np.asarray(
         [world[index] for edge in edge_indices for index in edge],
         dtype=np.float32,
+    )
+
+
+def _world_limits_for_shape(
+    shape: tuple[int, int, int],
+    affine: np.ndarray,
+) -> tuple[
+    tuple[float, float],
+    tuple[float, float],
+    tuple[float, float],
+]:
+    coordinates = source_box_world_segments(shape, affine).reshape(-1, 3)
+    minimum = np.min(coordinates, axis=0)
+    maximum = np.max(coordinates, axis=0)
+    return tuple(
+        (float(minimum[axis]), float(maximum[axis]))
+        for axis in range(3)
     )
 
 

--- a/src/mipview/viewer/render_3d_preparation.py
+++ b/src/mipview/viewer/render_3d_preparation.py
@@ -9,6 +9,7 @@ from skimage.measure import marching_cubes
 
 from mipview.io.nifti_io import NiftiLoadResult
 from mipview.patch.selector import PatchBounds
+from mipview.vessel_graph.model import VesselGraphRenderGeometry
 
 
 MAX_VOLUME_DIMENSION = 256
@@ -29,6 +30,59 @@ class PreparedRender3D:
     stride: tuple[int, int, int]
     source_range: tuple[float, float]
     mask_applied: bool = False
+    graph_edge_segments: np.ndarray | None = None
+    graph_node_positions: np.ndarray | None = None
+    graph_intercept_positions: np.ndarray | None = None
+
+
+def prepare_vessel_graph_render(
+    geometry: VesselGraphRenderGeometry,
+) -> PreparedRender3D:
+    """Prepare bounded batched line-and-marker arrays for a vessel graph."""
+    segments: list[np.ndarray] = []
+    for polyline in geometry.polylines_world:
+        path = np.asarray(polyline, dtype=np.float32)
+        if path.ndim != 2 or path.shape[1] != 3:
+            raise ValueError("Vessel graph polylines must be Nx3 world coordinates.")
+        if path.shape[0] >= 2:
+            segments.append(
+                np.stack((path[:-1], path[1:]), axis=1).reshape(-1, 3)
+            )
+    edge_segments = (
+        np.concatenate(segments, axis=0)
+        if segments
+        else np.empty((0, 3), dtype=np.float32)
+    )
+    nodes = np.asarray(geometry.node_world_positions, dtype=np.float32)
+    intercepts = np.asarray(geometry.intercept_world_positions, dtype=np.float32)
+    if nodes.ndim != 2 or nodes.shape[1:] != (3,):
+        raise ValueError("Vessel graph node positions must be Nx3.")
+    if intercepts.ndim != 2 or intercepts.shape[1:] != (3,):
+        raise ValueError("Vessel graph intercept positions must be Nx3.")
+    if not (
+        np.all(np.isfinite(edge_segments))
+        and np.all(np.isfinite(nodes))
+        and np.all(np.isfinite(intercepts))
+    ):
+        raise ValueError("Vessel graph render geometry must be finite.")
+    return PreparedRender3D(
+        kind="vessel_graph",
+        render_mode="Skeleton",
+        data=None,
+        vertices=None,
+        faces=None,
+        texture_affine=None,
+        prepared_shape=(
+            int(nodes.shape[0]),
+            int(edge_segments.shape[0] // 2),
+            int(intercepts.shape[0]),
+        ),
+        stride=(1, 1, 1),
+        source_range=(0.0, 0.0),
+        graph_edge_segments=edge_segments,
+        graph_node_positions=nodes,
+        graph_intercept_positions=intercepts,
+    )
 
 
 def prepare_render(

--- a/src/mipview/viewer/render_3d_state.py
+++ b/src/mipview/viewer/render_3d_state.py
@@ -5,26 +5,38 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from mipview.io.nifti_io import NiftiLoadResult
+from mipview.vessel_graph.model import VesselGraphRenderGeometry
 
 
 RAW_RENDER_MODES = ("MIP", "MinIP", "Translucent", "Isosurface")
 SEGMENTATION_RENDER_MODES = ("Surface", "Points")
+VESSEL_GRAPH_RENDER_MODES = ("Skeleton",)
 MASKED_IMAGE_RENDER_MODES = ("MIP", "MinIP")
 MASKED_SEGMENTATION_RENDER_MODES = SEGMENTATION_RENDER_MODES
 
 
 @dataclass(frozen=True)
 class Render3DSource:
-    """A loaded NIfTI volume available to one 3D viewer."""
+    """One standalone file layer available to a 3D viewer."""
 
     id: str
     display_name: str
-    volume: NiftiLoadResult
+    volume: NiftiLoadResult | None
     kind: str
+    vessel_graph: VesselGraphRenderGeometry | None = None
 
     def __post_init__(self) -> None:
-        if self.kind not in {"image", "segmentation"}:
-            raise ValueError("3D render source kind must be image or segmentation.")
+        if self.kind not in {"image", "segmentation", "vessel_graph"}:
+            raise ValueError(
+                "3D render source kind must be image, segmentation, or vessel_graph."
+            )
+        if self.kind == "vessel_graph":
+            if self.vessel_graph is None or self.volume is not None:
+                raise ValueError(
+                    "A vessel-graph 3D source requires graph geometry and no volume."
+                )
+        elif self.volume is None or self.vessel_graph is not None:
+            raise ValueError("A NIfTI 3D source requires a volume and no graph geometry.")
 
 
 @dataclass
@@ -37,6 +49,8 @@ class Render3DSettings:
     render_mode: str = "MIP"
     mask_source_id: str | None = None
     threshold: float = 0.0
+    node_size: int = 4
+    edge_thickness: int = 2
     dirty: bool = True
 
     def set_opacity(self, opacity: float) -> None:
@@ -46,6 +60,12 @@ class Render3DSettings:
         if len(colour) != 3 or any(not 0 <= int(value) <= 255 for value in colour):
             raise ValueError("3D layer colour must contain three values in 0..255.")
         self.colour = tuple(int(value) for value in colour)
+
+    def set_node_size(self, node_size: int) -> None:
+        self.node_size = min(max(int(node_size), 1), 10)
+
+    def set_edge_thickness(self, edge_thickness: int) -> None:
+        self.edge_thickness = min(max(int(edge_thickness), 1), 10)
 
 
 @dataclass
@@ -113,6 +133,8 @@ class Render3DState:
             candidate
             for candidate in self.sources.values()
             if candidate.kind == "segmentation"
+            and source.volume is not None
+            and candidate.volume is not None
             and _volumes_are_spatially_compatible(
                 source.volume,
                 candidate.volume,
@@ -139,6 +161,7 @@ class Render3DState:
             "busy": self.busy,
             "selected_source_id": self.selected_source_id,
             "selected_source_name": None if source is None else source.display_name,
+            "selected_source_kind": None if source is None else source.kind,
             "rendered_source_id": self.rendered_source_id,
             "visible": None if settings is None else settings.visible,
             "opacity": None if settings is None else settings.opacity,
@@ -159,6 +182,10 @@ class Render3DState:
                 and self.selected_mask_source() is not None
             ),
             "threshold": None if settings is None else settings.threshold,
+            "node_size": None if settings is None else settings.node_size,
+            "edge_thickness": (
+                None if settings is None else settings.edge_thickness
+            ),
             "update_required": None if settings is None else settings.dirty,
             "prepared_shape": (
                 None if self.prepared_shape is None else list(self.prepared_shape)
@@ -173,6 +200,13 @@ class Render3DState:
 
 
 def default_settings_for_source(source: Render3DSource) -> Render3DSettings:
+    if source.kind == "vessel_graph":
+        return Render3DSettings(
+            colour=(57, 255, 20),
+            render_mode="Skeleton",
+            threshold=0.0,
+        )
+    assert source.volume is not None
     data = source.volume.data
     sample_stride = max(1, int(np.ceil(max(data.shape) / 128)))
     sample = np.asarray(data[::sample_stride, ::sample_stride, ::sample_stride])

--- a/src/mipview/viewer/render_3d_state.py
+++ b/src/mipview/viewer/render_3d_state.py
@@ -9,6 +9,8 @@ from mipview.io.nifti_io import NiftiLoadResult
 
 RAW_RENDER_MODES = ("MIP", "MinIP", "Translucent", "Isosurface")
 SEGMENTATION_RENDER_MODES = ("Surface", "Points")
+MASKED_IMAGE_RENDER_MODES = ("MIP", "MinIP")
+MASKED_SEGMENTATION_RENDER_MODES = SEGMENTATION_RENDER_MODES
 
 
 @dataclass(frozen=True)
@@ -33,6 +35,7 @@ class Render3DSettings:
     opacity: float = 1.0
     colour: tuple[int, int, int] = (255, 255, 255)
     render_mode: str = "MIP"
+    mask_source_id: str | None = None
     threshold: float = 0.0
     dirty: bool = True
 
@@ -68,6 +71,11 @@ class Render3DState:
 
         for source in sources:
             self.settings.setdefault(source.id, default_settings_for_source(source))
+        for source_id, settings in self.settings.items():
+            if settings.mask_source_id not in {
+                source.id for source in self.compatible_masks_for(source_id)
+            }:
+                settings.mask_source_id = None
 
         if self.selected_source_id not in self.sources:
             self.selected_source_id = sources[0].id if sources else None
@@ -94,6 +102,35 @@ class Render3DState:
         if settings is not None:
             settings.dirty = True
 
+    def compatible_masks_for(
+        self,
+        source_id: str | None,
+    ) -> tuple[Render3DSource, ...]:
+        source = self.sources.get(source_id) if source_id is not None else None
+        if source is None:
+            return ()
+        return tuple(
+            candidate
+            for candidate in self.sources.values()
+            if candidate.kind == "segmentation"
+            and _volumes_are_spatially_compatible(
+                source.volume,
+                candidate.volume,
+            )
+        )
+
+    def selected_mask_source(self) -> Render3DSource | None:
+        settings = self.selected_settings()
+        if settings is None or settings.mask_source_id is None:
+            return None
+        compatible_ids = {
+            source.id
+            for source in self.compatible_masks_for(self.selected_source_id)
+        }
+        if settings.mask_source_id not in compatible_ids:
+            return None
+        return self.sources.get(settings.mask_source_id)
+
     def status(self) -> dict[str, object]:
         source = self.selected_source()
         settings = self.selected_settings()
@@ -107,6 +144,20 @@ class Render3DState:
             "opacity": None if settings is None else settings.opacity,
             "colour": None if settings is None else list(settings.colour),
             "render_mode": None if settings is None else settings.render_mode,
+            "mask_source_id": (
+                None if settings is None else settings.mask_source_id
+            ),
+            "mask_source_name": (
+                None
+                if settings is None or self.selected_mask_source() is None
+                else self.selected_mask_source().display_name
+            ),
+            "mask_applied": (
+                False
+                if source is None or settings is None
+                else render_mode_supports_mask(source.kind, settings.render_mode)
+                and self.selected_mask_source() is not None
+            ),
             "threshold": None if settings is None else settings.threshold,
             "update_required": None if settings is None else settings.dirty,
             "prepared_shape": (
@@ -136,3 +187,32 @@ def default_settings_for_source(source: Render3DSource) -> Render3DSettings:
             threshold=0.5,
         )
     return Render3DSettings(render_mode="MIP", threshold=threshold)
+
+
+def render_mode_supports_mask(source_kind: str, render_mode: str) -> bool:
+    if source_kind == "image":
+        return render_mode in MASKED_IMAGE_RENDER_MODES
+    if source_kind == "segmentation":
+        return render_mode in MASKED_SEGMENTATION_RENDER_MODES
+    return False
+
+
+def _volumes_are_spatially_compatible(
+    source: NiftiLoadResult,
+    mask: NiftiLoadResult,
+) -> bool:
+    return (
+        np.asarray(source.data).ndim == 3
+        and np.asarray(mask.data).ndim == 3
+        and source.shape == mask.shape
+        and np.asarray(source.affine).shape == (4, 4)
+        and np.asarray(mask.affine).shape == (4, 4)
+        and bool(
+            np.allclose(
+                source.affine,
+                mask.affine,
+                atol=1.0e-4,
+                rtol=0.0,
+            )
+        )
+    )

--- a/src/mipview/viewer/slice_viewer_widget.py
+++ b/src/mipview/viewer/slice_viewer_widget.py
@@ -30,6 +30,14 @@ from mipview.graph.spatial import (
 )
 from mipview.graph.vector import GraphVector, resolve_graph_vector
 from mipview.viewer.intensity import normalize_slice_to_uint8, window_slice_to_uint8
+from mipview.viewer.orientation_indicator import (
+    ORIENTATION_INDICATOR_LABELS,
+    ORIENTATION_INDICATOR_OFF,
+    ORIENTATION_INDICATOR_WIDGET,
+    OrientationIndicatorMode,
+    normalize_orientation_indicator_mode,
+    orientation_axis_colour,
+)
 from mipview.segmentation.overlay import build_segmentation_overlay_rgba
 from mipview.viewer.oriented_volume import OrientedVolume
 from mipview.viewer.ruler import display_voxel_spacing_mm, select_ruler_geometry
@@ -97,6 +105,9 @@ class SliceViewerWidget(QWidget):
         self._zoom_factor = 1.0
         self._pan_offset = (0.0, 0.0)
         self._cursor_overlay_visible = True
+        self._orientation_indicator_mode: OrientationIndicatorMode = (
+            ORIENTATION_INDICATOR_LABELS
+        )
         self._ruler_visible = True
         self._patch_overlay_visible = False
         self._patch_overlay_opacity = 0.5
@@ -247,6 +258,16 @@ class SliceViewerWidget(QWidget):
     def set_cursor_overlay_visible(self, visible: bool) -> None:
         self._cursor_overlay_visible = visible
         self._update_scaled_pixmap()
+
+    def set_orientation_indicator_mode(self, mode: str) -> None:
+        normalized = normalize_orientation_indicator_mode(mode)
+        if normalized == self._orientation_indicator_mode:
+            return
+        self._orientation_indicator_mode = normalized
+        self._update_scaled_pixmap()
+
+    def orientation_indicator_mode(self) -> OrientationIndicatorMode:
+        return self._orientation_indicator_mode
 
     def set_ruler_visible(self, visible: bool) -> None:
         self._ruler_visible = bool(visible)
@@ -605,8 +626,6 @@ class SliceViewerWidget(QWidget):
         )
         self._draw_segmentation_overlay(painter, display_rect)
         self._draw_annotation_overlay(painter, display_rect)
-        self._draw_orientation_indicators(painter)
-
         if (
             self._patch_overlay_visible
             and self._patch_plane_bounds is not None
@@ -631,6 +650,7 @@ class SliceViewerWidget(QWidget):
 
         self._draw_graph_overlay(painter, display_rect)
         self._draw_ruler(painter, display_rect)
+        self._draw_orientation_indicator(painter)
         painter.end()
 
         self.image_label.setPixmap(canvas)
@@ -1939,7 +1959,17 @@ class SliceViewerWidget(QWidget):
                 self.PATCH_HANDLE_RADIUS,
             )
 
-    def _draw_orientation_indicators(self, painter: QPainter) -> None:
+    def _draw_orientation_indicator(self, painter: QPainter) -> None:
+        if self._orientation_indicator_mode == ORIENTATION_INDICATOR_LABELS:
+            self._draw_orientation_labels(painter)
+        elif self._orientation_indicator_mode == ORIENTATION_INDICATOR_WIDGET:
+            self._draw_orientation_widget(painter)
+        elif self._orientation_indicator_mode != ORIENTATION_INDICATOR_OFF:
+            raise ValueError(
+                f"Unsupported orientation mode: {self._orientation_indicator_mode}"
+            )
+
+    def _draw_orientation_labels(self, painter: QPainter) -> None:
         indicators = orientation_indicators_for_orientation(self.orientation)
         indicator_font = QFont(self._fixed_orientation_indicator_font)
         indicator_font.setBold(True)
@@ -1968,6 +1998,127 @@ class SliceViewerWidget(QWidget):
             rect.adjusted(0, 0, 0, -margin),
             Qt.AlignmentFlag.AlignBottom | Qt.AlignmentFlag.AlignHCenter,
             indicators.bottom,
+        )
+
+    def _draw_orientation_widget(self, painter: QPainter) -> None:
+        indicators = orientation_indicators_for_orientation(self.orientation)
+        widget_extent = 38.0
+        center = QPointF(
+            max(
+                widget_extent + 8.0,
+                self.image_label.width() - widget_extent - 10.0,
+            ),
+            max(
+                widget_extent + 8.0,
+                self.image_label.height() - widget_extent - 10.0,
+            ),
+        )
+
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        arrow_radius = 23.0
+        labelled_endpoints = (
+            (
+                indicators.left,
+                QPointF(center.x() - arrow_radius, center.y()),
+            ),
+            (
+                indicators.right,
+                QPointF(center.x() + arrow_radius, center.y()),
+            ),
+            (
+                indicators.top,
+                QPointF(center.x(), center.y() - arrow_radius),
+            ),
+            (
+                indicators.bottom,
+                QPointF(center.x(), center.y() + arrow_radius),
+            ),
+        )
+        for label, endpoint in labelled_endpoints:
+            self._draw_orientation_arrow(
+                painter,
+                center,
+                endpoint,
+                QColor(orientation_axis_colour(label)),
+            )
+
+        label_font = QFont(self._fixed_orientation_indicator_font)
+        label_font.setBold(True)
+        painter.setFont(label_font)
+        label_radius = 30.0
+        label_size = 16.0
+        labelled_centers = (
+            (
+                indicators.left,
+                QPointF(center.x() - label_radius, center.y()),
+            ),
+            (
+                indicators.right,
+                QPointF(center.x() + label_radius, center.y()),
+            ),
+            (
+                indicators.top,
+                QPointF(center.x(), center.y() - label_radius),
+            ),
+            (
+                indicators.bottom,
+                QPointF(center.x(), center.y() + label_radius),
+            ),
+        )
+        for label, label_center in labelled_centers:
+            painter.setPen(QPen(QColor(orientation_axis_colour(label))))
+            painter.drawText(
+                QRectF(
+                    label_center.x() - label_size / 2.0,
+                    label_center.y() - label_size / 2.0,
+                    label_size,
+                    label_size,
+                ),
+                Qt.AlignmentFlag.AlignCenter,
+                label,
+            )
+        painter.restore()
+
+    @staticmethod
+    def _draw_orientation_arrow(
+        painter: QPainter,
+        start: QPointF,
+        end: QPointF,
+        colour: QColor,
+    ) -> None:
+        axis_pen = QPen(colour, 2)
+        axis_pen.setCosmetic(True)
+        painter.setPen(axis_pen)
+        painter.setBrush(colour)
+        painter.drawLine(start, end)
+        delta_x = end.x() - start.x()
+        delta_y = end.y() - start.y()
+        length = float(np.hypot(delta_x, delta_y))
+        if length <= 0.0:
+            return
+        unit_x = delta_x / length
+        unit_y = delta_y / length
+        perpendicular_x = -unit_y
+        perpendicular_y = unit_x
+        head_length = 5.0
+        head_width = 3.5
+        base_x = end.x() - unit_x * head_length
+        base_y = end.y() - unit_y * head_length
+        painter.drawPolygon(
+            QPolygonF(
+                [
+                    end,
+                    QPointF(
+                        base_x + perpendicular_x * head_width,
+                        base_y + perpendicular_y * head_width,
+                    ),
+                    QPointF(
+                        base_x - perpendicular_x * head_width,
+                        base_y - perpendicular_y * head_width,
+                    ),
+                ]
+            )
         )
 
     def _start_patch_resize_if_hit(self, label_position: QPointF) -> bool:

--- a/src/mipview/viewer/slice_viewer_widget.py
+++ b/src/mipview/viewer/slice_viewer_widget.py
@@ -29,6 +29,12 @@ from mipview.graph.spatial import (
     normal_line_plane_endpoints,
 )
 from mipview.graph.vector import GraphVector, resolve_graph_vector
+from mipview.vessel_graph.model import (
+    PROJECTED_INTERCEPT_COLOR,
+    VESSEL_EDGE_COLOR,
+    VESSEL_NODE_COLOR,
+    ProjectedVesselGraphLayer,
+)
 from mipview.viewer.intensity import normalize_slice_to_uint8, window_slice_to_uint8
 from mipview.viewer.orientation_indicator import (
     ORIENTATION_INDICATOR_LABELS,
@@ -154,6 +160,11 @@ class SliceViewerWidget(QWidget):
         self._graph_normal_line_thickness = 1
         self._graph_extension_line_edge: GraphEdge | None = None
         self._graph_extension_line_thickness = 1
+        self._vessel_graph_layer: ProjectedVesselGraphLayer | None = None
+        self._vessel_graph_visible = False
+        self._vessel_graph_opacity = 1.0
+        self._vessel_graph_node_size = 4
+        self._vessel_graph_edge_thickness = 2
         self._active_patch_resize_handle: str | None = None
         self._interaction_mode: str | None = None
         self._last_drag_position: QPointF | None = None
@@ -338,6 +349,26 @@ class SliceViewerWidget(QWidget):
             and self._graph_pending_vector_source_node_id is None
         ):
             self._graph_preview_label_position = None
+        self._update_scaled_pixmap()
+
+    def set_vessel_graph_overlay(
+        self,
+        layer: ProjectedVesselGraphLayer | None,
+        *,
+        visible: bool,
+        opacity: float,
+        node_size: int,
+        edge_thickness: int,
+    ) -> None:
+        """Set the independent, read-only GraphML projection layer."""
+        self._vessel_graph_layer = layer
+        self._vessel_graph_visible = bool(visible)
+        self._vessel_graph_opacity = min(max(float(opacity), 0.0), 1.0)
+        self._vessel_graph_node_size = min(max(int(node_size), 1), 10)
+        self._vessel_graph_edge_thickness = min(
+            max(int(edge_thickness), 1),
+            10,
+        )
         self._update_scaled_pixmap()
 
     def set_patch_overlay(
@@ -648,6 +679,7 @@ class SliceViewerWidget(QWidget):
             painter.drawLine(crosshair_x, 0, crosshair_x, canvas.height() - 1)
             painter.drawLine(0, crosshair_y, canvas.width() - 1, crosshair_y)
 
+        self._draw_vessel_graph_overlay(painter, display_rect)
         self._draw_graph_overlay(painter, display_rect)
         self._draw_ruler(painter, display_rect)
         self._draw_orientation_indicator(painter)
@@ -754,6 +786,81 @@ class SliceViewerWidget(QWidget):
                 painter.setPen(preview_pen)
                 painter.setBrush(Qt.BrushStyle.NoBrush)
                 painter.drawLine(start, self._graph_preview_label_position)
+        painter.restore()
+
+    def _draw_vessel_graph_overlay(
+        self,
+        painter: QPainter,
+        display_rect: DisplayRect,
+    ) -> None:
+        layer = self._vessel_graph_layer
+        if (
+            layer is None
+            or not self._vessel_graph_visible
+            or self._vessel_graph_opacity <= 0.0
+            or self._projection_slice_2d is None
+            or layer.plane_shape
+            != (
+                int(self._projection_slice_2d.shape[1]),
+                int(self._projection_slice_2d.shape[0]),
+            )
+        ):
+            return
+
+        alpha = int(round(self._vessel_graph_opacity * 255.0))
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        edge_pen = QPen(
+            QColor(*VESSEL_EDGE_COLOR, alpha),
+            self._vessel_graph_edge_thickness,
+        )
+        edge_pen.setCosmetic(True)
+        painter.setPen(edge_pen)
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        for polyline in layer.polylines:
+            if polyline.shape[0] < 2:
+                continue
+            path = QPainterPath(
+                self._projection_point_to_screen(
+                    polyline[0],
+                    layer.plane_shape,
+                    display_rect,
+                )
+            )
+            for point in polyline[1:]:
+                path.lineTo(
+                    self._projection_point_to_screen(
+                        point,
+                        layer.plane_shape,
+                        display_rect,
+                    )
+                )
+            painter.drawPath(path)
+
+        painter.setPen(Qt.PenStyle.NoPen)
+        radius = float(self._vessel_graph_node_size)
+        painter.setBrush(QColor(*VESSEL_NODE_COLOR, alpha))
+        for point in layer.node_positions:
+            painter.drawEllipse(
+                self._projection_point_to_screen(
+                    point,
+                    layer.plane_shape,
+                    display_rect,
+                ),
+                radius,
+                radius,
+            )
+        painter.setBrush(QColor(*PROJECTED_INTERCEPT_COLOR, alpha))
+        for point in layer.intercept_positions:
+            painter.drawEllipse(
+                self._projection_point_to_screen(
+                    point,
+                    layer.plane_shape,
+                    display_rect,
+                ),
+                radius,
+                radius,
+            )
         painter.restore()
 
     def _draw_graph_construction_lines(
@@ -1130,7 +1237,19 @@ class SliceViewerWidget(QWidget):
     ) -> QPointF:
         assert self._graph_layer is not None
         assert self._graph_layer.plane_shape is not None
-        width, height = self._graph_layer.plane_shape
+        return self._projection_point_to_screen(
+            point,
+            self._graph_layer.plane_shape,
+            display_rect,
+        )
+
+    @staticmethod
+    def _projection_point_to_screen(
+        point: tuple[float, float] | np.ndarray,
+        plane_shape: tuple[int, int],
+        display_rect: DisplayRect,
+    ) -> QPointF:
+        width, height = plane_shape
         return QPointF(
             display_rect.left + (((float(point[0]) + 0.5) / width) * display_rect.width),
             display_rect.top + (((float(point[1]) + 0.5) / height) * display_rect.height),

--- a/src/mipview/viewer/triplanar_viewer_widget.py
+++ b/src/mipview/viewer/triplanar_viewer_widget.py
@@ -34,6 +34,11 @@ from mipview.patch.selector import (
     source_bounds_to_display_bounds,
 )
 from mipview.viewer.oriented_volume import OrientedVolume, build_oriented_volume
+from mipview.viewer.orientation_indicator import (
+    ORIENTATION_INDICATOR_LABELS,
+    OrientationIndicatorMode,
+    normalize_orientation_indicator_mode,
+)
 from mipview.viewer.ruler import spatial_unit_to_mm
 from mipview.viewer.slice_geometry import (
     Orientation,
@@ -52,12 +57,14 @@ VIEW_MODE_AXIAL = "axial"
 VIEW_MODE_SAGITTAL = "sagittal"
 VIEW_MODE_CORONAL = "coronal"
 VIEW_MODE_3D = "3d"
+VIEW_MODE_ORTHOGONAL = "orthogonal"
 VIEW_MODE_ORTHOGONAL_3D = "orthogonal_3d"
 VIEW_MODES = (
     VIEW_MODE_AXIAL,
     VIEW_MODE_SAGITTAL,
     VIEW_MODE_CORONAL,
     VIEW_MODE_3D,
+    VIEW_MODE_ORTHOGONAL,
     VIEW_MODE_ORTHOGONAL_3D,
 )
 
@@ -199,6 +206,9 @@ class TriPlanarViewerWidget(QWidget):
         self._projection_segmentation_enabled = True
         self._projection_segmentation_source: str | None = "all"
         self._active_view: Orientation | None = None
+        self._orientation_indicator_mode: OrientationIndicatorMode = (
+            ORIENTATION_INDICATOR_LABELS
+        )
         self._drop_loading_enabled = False
         self._projection_enabled: dict[str, bool] = {
             "axial": False,
@@ -367,6 +377,16 @@ class TriPlanarViewerWidget(QWidget):
             self._viewer_splitter.setSizes(root)
             self._top_splitter.setSizes(top)
             self._bottom_splitter.setSizes(bottom)
+        elif self._view_mode == VIEW_MODE_ORTHOGONAL:
+            self._top_splitter.insertWidget(0, self.axial_view)
+            self._top_splitter.insertWidget(1, self.coronal_view)
+            self._top_splitter.insertWidget(2, self.sagittal_view)
+            self.axial_view.setVisible(True)
+            self.coronal_view.setVisible(True)
+            self.sagittal_view.setVisible(True)
+            self._top_splitter.setSizes(
+                self._splitter_sizes.get(VIEW_MODE_ORTHOGONAL, ([1, 1, 1],))[0]
+            )
         else:
             selected_widget = {
                 VIEW_MODE_AXIAL: self.axial_view,
@@ -384,6 +404,11 @@ class TriPlanarViewerWidget(QWidget):
         *,
         volume_active: bool | None = None,
     ) -> None:
+        if self._view_mode == VIEW_MODE_ORTHOGONAL:
+            candidate = self._top_splitter.sizes()
+            if sum(candidate) > 0:
+                self._splitter_sizes[VIEW_MODE_ORTHOGONAL] = (candidate,)
+            return
         if self._view_mode != VIEW_MODE_ORTHOGONAL_3D:
             return
         _ = volume_active
@@ -403,6 +428,7 @@ class TriPlanarViewerWidget(QWidget):
             )
 
         self._display_volume = build_oriented_volume(volume.data, volume.affine)
+        self.volume_3d_view.set_volume_geometry(volume.shape, volume.affine)
         unit_scale_to_mm = spatial_unit_to_mm(volume.header.get_xyzt_units()[0])
         # Reset cursor state before reloading the views so the initial cursor
         # is always re-emitted into the freshly cleared slice widgets.
@@ -457,6 +483,7 @@ class TriPlanarViewerWidget(QWidget):
 
     def unload_volume(self) -> None:
         self.volume_3d_view.dismiss()
+        self.volume_3d_view.set_volume_geometry(None, None)
         self._display_volume = None
         self._segmentation_display_volume = None
         self._projection_mask_display_volume = None
@@ -507,6 +534,19 @@ class TriPlanarViewerWidget(QWidget):
     def set_cursor_overlay_visible(self, visible: bool) -> None:
         for view in self._views:
             view.set_cursor_overlay_visible(visible)
+        self.volume_3d_view.set_cursor_overlay_visible(visible)
+
+    def set_orientation_indicator_mode(self, mode: str) -> None:
+        normalized = normalize_orientation_indicator_mode(mode)
+        if normalized == self._orientation_indicator_mode:
+            return
+        self._orientation_indicator_mode = normalized
+        for view in self._views:
+            view.set_orientation_indicator_mode(normalized)
+        self.volume_3d_view.set_orientation_indicator_mode(normalized)
+
+    def orientation_indicator_mode(self) -> OrientationIndicatorMode:
+        return self._orientation_indicator_mode
 
     def set_ruler_visible(self, visible: bool) -> None:
         for view in self._views:
@@ -951,7 +991,8 @@ class TriPlanarViewerWidget(QWidget):
         self._emit_dropped_path(dropped_path)
 
     def eventFilter(self, watched: QObject, event: QEvent) -> bool:
-        if watched in self._drop_event_sources and self._handle_drop_event(event):
+        drop_event_sources = getattr(self, "_drop_event_sources", ())
+        if watched in drop_event_sources and self._handle_drop_event(event):
             return True
         return super().eventFilter(watched, event)
 
@@ -966,6 +1007,7 @@ class TriPlanarViewerWidget(QWidget):
         cursor_position = (x, y, z)
         for view in self._views:
             view.set_cursor_position(cursor_position)
+        self.volume_3d_view.set_cursor_position(cursor_position)
 
         intensity = self._display_volume.source_data[x, y, z].item()
         self.cursor_inspection_changed.emit(x, y, z, intensity)

--- a/src/mipview/viewer/triplanar_viewer_widget.py
+++ b/src/mipview/viewer/triplanar_viewer_widget.py
@@ -18,8 +18,14 @@ from mipview.graph.spatial import (
     resolve_projection_voxel,
     update_control_point_from_projection,
 )
+from mipview.vessel_graph.model import (
+    ClippedVesselGraph,
+    VesselGraphDisplaySettings,
+)
+from mipview.vessel_graph.spatial import project_clipped_vessel_graph
 from mipview.ui.drop_loading import (
     first_supported_local_drop_path,
+    is_supported_graphml_path,
     is_supported_graph_state_path,
 )
 from mipview.state.cursor_state import CursorState
@@ -151,6 +157,7 @@ class TriPlanarViewerWidget(QWidget):
     annotation_changed = Signal(object)
     annotation_undo_availability_changed = Signal(bool)
     nifti_file_dropped = Signal(object)
+    graphml_file_dropped = Signal(object)
     graph_state_file_dropped = Signal(object)
     projection_state_changed = Signal(str, object)
     graph_context_requested = Signal(str, object, object, object)
@@ -189,6 +196,8 @@ class TriPlanarViewerWidget(QWidget):
         self._annotation_brush_mode: str = "paint"
         self._annotation_undo_stack = AnnotationUndoStack()
         self._projection_graph_state: ProjectionGraphState | None = None
+        self._vessel_graph_geometry: ClippedVesselGraph | None = None
+        self._vessel_graph_settings = VesselGraphDisplaySettings()
         self._contrast_window: tuple[float, float] | None = None
         patch_debug_value = os.getenv("MIPVIEW_PATCH_DEBUG")
         if patch_debug_value is None:
@@ -451,6 +460,7 @@ class TriPlanarViewerWidget(QWidget):
         self.patch_selector.set_center(initial_center)
         self.cursor_state.set_cursor_position(initial_center)
         self._update_projection_overrides()
+        self.refresh_vessel_graph_overlay()
 
     def replace_volume(
         self,
@@ -490,6 +500,7 @@ class TriPlanarViewerWidget(QWidget):
         self._annotation_mask = None
         self._annotation_display_volume = None
         self._annotation_editing_enabled = False
+        self._vessel_graph_geometry = None
         self._active_view = None
         self.cursor_state.clear()
         self.zoom_state.set_zoom_factor(1.0)
@@ -512,6 +523,13 @@ class TriPlanarViewerWidget(QWidget):
                 None,
             )
             view.set_projection_slice(None)
+            view.set_vessel_graph_overlay(
+                None,
+                visible=False,
+                opacity=0.0,
+                node_size=1,
+                edge_thickness=1,
+            )
         self.patch_selection_changed.emit(None)
 
     def current_cursor_position(self) -> tuple[int, int, int] | None:
@@ -630,6 +648,7 @@ class TriPlanarViewerWidget(QWidget):
             return
         self._projection_enabled[orientation] = enabled
         self._update_projection_overrides()
+        self.refresh_vessel_graph_overlay()
         self.projection_state_changed.emit(
             self._projection_mode,
             self.enabled_projection_orientations(),
@@ -675,6 +694,43 @@ class TriPlanarViewerWidget(QWidget):
         self._projection_graph_state = graph_state
         self._sync_graph_plane_shapes()
         self.refresh_graph_overlay()
+
+    def set_vessel_graph_projection(
+        self,
+        geometry: ClippedVesselGraph | None,
+        settings: VesselGraphDisplaySettings | None = None,
+    ) -> None:
+        self._vessel_graph_geometry = geometry
+        if settings is not None:
+            self._vessel_graph_settings = settings
+        self.refresh_vessel_graph_overlay()
+
+    def refresh_vessel_graph_overlay(self) -> None:
+        for view in self._views:
+            if (
+                self._vessel_graph_geometry is None
+                or self._display_volume is None
+                or not self.projection_enabled(view.orientation)
+            ):
+                view.set_vessel_graph_overlay(
+                    None,
+                    visible=False,
+                    opacity=0.0,
+                    node_size=1,
+                    edge_thickness=1,
+                )
+                continue
+            view.set_vessel_graph_overlay(
+                project_clipped_vessel_graph(
+                    self._vessel_graph_geometry,
+                    self._display_volume,
+                    view.orientation,
+                ),
+                visible=self._vessel_graph_settings.visible,
+                opacity=self._vessel_graph_settings.opacity,
+                node_size=self._vessel_graph_settings.node_size,
+                edge_thickness=self._vessel_graph_settings.edge_thickness,
+            )
 
     def refresh_graph_overlay(self) -> None:
         graph_state = self._projection_graph_state
@@ -1388,6 +1444,8 @@ class TriPlanarViewerWidget(QWidget):
     def _emit_dropped_path(self, dropped_path: Path) -> None:
         if is_supported_graph_state_path(dropped_path):
             self.graph_state_file_dropped.emit(dropped_path)
+        elif is_supported_graphml_path(dropped_path):
+            self.graphml_file_dropped.emit(dropped_path)
         else:
             self.nifti_file_dropped.emit(dropped_path)
 

--- a/src/mipview/viewer/volume_3d_widget.py
+++ b/src/mipview/viewer/volume_3d_widget.py
@@ -1,18 +1,46 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
-from PySide6.QtCore import QObject, QRunnable, QThreadPool, Qt, Signal, Slot
-from PySide6.QtGui import QCloseEvent
+from PySide6.QtCore import (
+    QEvent,
+    QObject,
+    QPointF,
+    QRectF,
+    QRunnable,
+    QThreadPool,
+    Qt,
+    Signal,
+    Slot,
+)
+from PySide6.QtGui import (
+    QCloseEvent,
+    QColor,
+    QFont,
+    QPaintEvent,
+    QPainter,
+    QPen,
+    QPolygonF,
+)
 from PySide6.QtWidgets import QApplication, QLabel, QVBoxLayout, QWidget
 
 from mipview.io.nifti_io import NiftiLoadResult
 from mipview.patch.selector import PatchBounds
 from mipview.ui.volume_3d_panel import Volume3DPanel
+from mipview.viewer.orientation_indicator import (
+    ORIENTATION_INDICATOR_LABELS,
+    ORIENTATION_INDICATOR_WIDGET,
+    OrientationIndicatorMode,
+    normalize_orientation_indicator_mode,
+    orientation_axis_colour,
+)
 from mipview.viewer.render_3d_preparation import (
     PreparedRender3D,
+    cursor_world_position,
+    orientation_label_world_positions,
     patch_box_world_segments,
     prepare_render,
     source_box_world_segments,
@@ -67,6 +95,219 @@ class _PatchBoxState:
     visible: bool = False
 
 
+class _Volume3DCursorOverlay(QWidget):
+    """Mouse-transparent cursor and orientation overlay above the VisPy canvas."""
+
+    def __init__(
+        self,
+        position_provider: Callable[[], tuple[float, float] | None],
+        mode_provider: Callable[[], OrientationIndicatorMode],
+        orientation_provider: Callable[
+            [], tuple[tuple[str, float, float], ...]
+        ],
+        widget_provider: Callable[
+            [], tuple[tuple[str, float, float], ...]
+        ],
+        parent: QWidget,
+    ) -> None:
+        super().__init__(parent)
+        self._position_provider = position_provider
+        self._mode_provider = mode_provider
+        self._orientation_provider = orientation_provider
+        self._widget_provider = widget_provider
+        self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents, True)
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setAutoFillBackground(False)
+        parent.installEventFilter(self)
+        self.setGeometry(parent.rect())
+        self.show()
+        self.raise_()
+
+    def detach(self) -> None:
+        parent = self.parentWidget()
+        if parent is not None:
+            parent.removeEventFilter(self)
+        self.close()
+        self.setParent(None)
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        parent = self.parentWidget()
+        if watched is parent and event.type() in {
+            QEvent.Type.Resize,
+            QEvent.Type.Show,
+        }:
+            self.setGeometry(parent.rect())
+            self.raise_()
+            self.update()
+        return False
+
+    def paintEvent(self, event: QPaintEvent) -> None:
+        _ = event
+        position = self._position_provider()
+        orientation_mode = self._mode_provider()
+        orientation_labels = (
+            self._orientation_provider()
+            if orientation_mode == ORIENTATION_INDICATOR_LABELS
+            else ()
+        )
+        orientation_widget = (
+            self._widget_provider()
+            if orientation_mode == ORIENTATION_INDICATOR_WIDGET
+            else ()
+        )
+        if (
+            position is None
+            and not orientation_labels
+            and not orientation_widget
+        ):
+            return
+
+        painter = QPainter(self)
+        if position is not None:
+            x = int(round(position[0]))
+            y = int(round(position[1]))
+            if 0 <= x < self.width() and 0 <= y < self.height():
+                painter.setRenderHint(QPainter.RenderHint.Antialiasing, False)
+                pen = QPen(QColor("#ffb000"))
+                pen.setWidth(1)
+                painter.setPen(pen)
+                painter.drawLine(x, 0, x, self.height() - 1)
+                painter.drawLine(0, y, self.width() - 1, y)
+
+        if orientation_labels:
+            painter.setRenderHint(QPainter.RenderHint.TextAntialiasing, True)
+            label_font = QFont(self.font())
+            label_font.setBold(True)
+            painter.setFont(label_font)
+            painter.setPen(QPen(QColor("#ffd400")))
+            font_metrics = painter.fontMetrics()
+            margin = 8.0
+            for label, projected_x, projected_y in orientation_labels:
+                text_width = max(float(font_metrics.horizontalAdvance(label) + 6), 16.0)
+                text_height = max(float(font_metrics.height() + 4), 16.0)
+                center_x = min(
+                    max(float(projected_x), margin + text_width / 2.0),
+                    max(margin + text_width / 2.0, self.width() - margin - text_width / 2.0),
+                )
+                center_y = min(
+                    max(float(projected_y), margin + text_height / 2.0),
+                    max(
+                        margin + text_height / 2.0,
+                        self.height() - margin - text_height / 2.0,
+                    ),
+                )
+                painter.drawText(
+                    QRectF(
+                        center_x - text_width / 2.0,
+                        center_y - text_height / 2.0,
+                        text_width,
+                        text_height,
+                    ),
+                    Qt.AlignmentFlag.AlignCenter,
+                    label,
+                )
+        if orientation_widget:
+            self._draw_orientation_widget(painter, orientation_widget)
+        painter.end()
+
+    def _draw_orientation_widget(
+        self,
+        painter: QPainter,
+        axes: tuple[tuple[str, float, float], ...],
+    ) -> None:
+        widget_extent = 42.0
+        center = np.asarray(
+            [
+                max(
+                    widget_extent + 8.0,
+                    self.width() - widget_extent - 10.0,
+                ),
+                max(
+                    widget_extent + 8.0,
+                    self.height() - widget_extent - 10.0,
+                ),
+            ],
+            dtype=np.float64,
+        )
+        painter.save()
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+
+        label_font = QFont(self.font())
+        label_font.setBold(True)
+        painter.setFont(label_font)
+        axis_length = 25.0
+        for index, (label, direction_x, direction_y) in enumerate(axes):
+            colour = QColor(orientation_axis_colour(label))
+            direction = np.asarray(
+                [direction_x, direction_y],
+                dtype=np.float64,
+            )
+            projected_length = float(np.linalg.norm(direction))
+            if projected_length <= 1.0e-6:
+                painter.setPen(QPen(colour, 2))
+                painter.setBrush(colour)
+                painter.drawEllipse(QPointF(*center), 3.0, 3.0)
+                label_center = center + np.asarray(
+                    [(index - 1) * 13.0, -9.0],
+                    dtype=np.float64,
+                )
+            else:
+                endpoint = center + direction * axis_length
+                self._draw_widget_arrow(
+                    painter,
+                    QPointF(*center),
+                    QPointF(*endpoint),
+                    colour,
+                )
+                label_center = endpoint + (
+                    direction / projected_length
+                ) * 8.0
+            painter.setPen(QPen(colour))
+            painter.drawText(
+                QRectF(
+                    float(label_center[0] - 8.0),
+                    float(label_center[1] - 8.0),
+                    16.0,
+                    16.0,
+                ),
+                Qt.AlignmentFlag.AlignCenter,
+                label,
+            )
+        painter.restore()
+
+    @staticmethod
+    def _draw_widget_arrow(
+        painter: QPainter,
+        start: QPointF,
+        end: QPointF,
+        colour: QColor,
+    ) -> None:
+        pen = QPen(colour, 2)
+        pen.setCosmetic(True)
+        painter.setPen(pen)
+        painter.setBrush(colour)
+        painter.drawLine(start, end)
+        delta = np.asarray(
+            [end.x() - start.x(), end.y() - start.y()],
+            dtype=np.float64,
+        )
+        length = float(np.linalg.norm(delta))
+        if length <= 0.0:
+            return
+        unit = delta / length
+        perpendicular = np.asarray([-unit[1], unit[0]])
+        base = np.asarray([end.x(), end.y()]) - unit * 6.0
+        painter.drawPolygon(
+            QPolygonF(
+                [
+                    end,
+                    QPointF(*(base + perpendicular * 4.0)),
+                    QPointF(*(base - perpendicular * 4.0)),
+                ]
+            )
+        )
+
+
 class Volume3DWidget(QWidget):
     """Lazy VisPy scene for one isolated NIfTI layer plus locator geometry."""
 
@@ -90,6 +331,14 @@ class Volume3DWidget(QWidget):
         self._patch_visual: Any | None = None
         self._source_box_visual: Any | None = None
         self._locator_visual: Any | None = None
+        self._cursor_overlay: _Volume3DCursorOverlay | None = None
+        self._volume_shape: tuple[int, int, int] | None = None
+        self._volume_affine: np.ndarray | None = None
+        self._cursor_position: tuple[int, int, int] | None = None
+        self._cursor_visible = True
+        self._orientation_indicator_mode: OrientationIndicatorMode = (
+            ORIENTATION_INDICATOR_LABELS
+        )
         self._locator_volume: NiftiLoadResult | None = None
         self._locator_visible = False
         self._locator_source_shape: tuple[int, int, int] | None = None
@@ -212,6 +461,8 @@ class Volume3DWidget(QWidget):
             self._panel.set_status("Choose a layer and click Update.")
         self._refresh_patch_visual()
         self._refresh_locator_visual()
+        self._refresh_cursor_overlay()
+        self._refresh_orientation_overlay()
         self._emit_state()
         self.active_changed.emit(True)
 
@@ -376,6 +627,12 @@ class Volume3DWidget(QWidget):
                     self._locator_source_affine,
                 )
 
+        if self._volume_shape is not None and self._volume_affine is not None:
+            return _volume_world_limits(
+                self._volume_shape,
+                self._volume_affine,
+            )
+
         prepared = self._prepared
         if prepared is None:
             return None
@@ -401,6 +658,59 @@ class Volume3DWidget(QWidget):
             visible=bool(visible),
         )
         self._refresh_patch_visual()
+
+    def set_volume_geometry(
+        self,
+        shape: tuple[int, int, int] | None,
+        affine: np.ndarray | None,
+    ) -> None:
+        """Set source voxel geometry used by the cursor and orientation labels."""
+        if shape is None or affine is None:
+            self._volume_shape = None
+            self._volume_affine = None
+            self._cursor_position = None
+        else:
+            normalized_shape = tuple(int(value) for value in shape)
+            if len(normalized_shape) != 3 or any(
+                value <= 0 for value in normalized_shape
+            ):
+                raise ValueError(
+                    "3D source geometry must contain three positive shape values."
+                )
+            normalized_affine = np.asarray(affine, dtype=np.float64)
+            if normalized_affine.shape != (4, 4):
+                raise ValueError(
+                    f"3D source affine must be 4x4, got {normalized_affine.shape}."
+                )
+            self._volume_shape = normalized_shape
+            self._volume_affine = normalized_affine
+        self._refresh_cursor_overlay()
+        self._refresh_orientation_overlay()
+
+    def set_cursor_position(
+        self,
+        cursor_position: tuple[int, int, int] | None,
+    ) -> None:
+        self._cursor_position = (
+            None
+            if cursor_position is None
+            else tuple(int(value) for value in cursor_position)
+        )
+        self._refresh_cursor_overlay()
+
+    def set_cursor_overlay_visible(self, visible: bool) -> None:
+        self._cursor_visible = bool(visible)
+        self._refresh_cursor_overlay()
+
+    def set_orientation_indicator_mode(self, mode: str) -> None:
+        normalized = normalize_orientation_indicator_mode(mode)
+        if normalized == self._orientation_indicator_mode:
+            return
+        self._orientation_indicator_mode = normalized
+        self._refresh_orientation_overlay()
+
+    def orientation_indicator_mode(self) -> OrientationIndicatorMode:
+        return self._orientation_indicator_mode
 
     def set_locator_context(
         self,
@@ -437,6 +747,15 @@ class Volume3DWidget(QWidget):
         status = self.state.status()
         status["locator_visible"] = self._locator_visible
         status["patch_box_visible"] = self._patch_box.visible
+        status["cursor_visible"] = self._cursor_visible
+        status["cursor_position"] = (
+            None
+            if self._cursor_position is None
+            else list(self._cursor_position)
+        )
+        status["orientation_indicator_mode"] = (
+            self._orientation_indicator_mode
+        )
         return status
 
     def closeEvent(self, event: QCloseEvent) -> None:
@@ -513,9 +832,25 @@ class Volume3DWidget(QWidget):
         native.show()
         self._canvas = canvas
         self._view = canvas.central_widget.add_view()
-        self._view.camera = scene.cameras.TurntableCamera(
+        class _MiddlePanTurntableCamera(scene.cameras.TurntableCamera):
+            def viewbox_mouse_event(camera_self: Any, event: Any) -> None:
+                if _pan_camera_with_middle_drag(camera_self, event):
+                    return
+                super().viewbox_mouse_event(event)
+
+        self._view.camera = _MiddlePanTurntableCamera(
             fov=45.0,
             up="+z",
+        )
+        self._cursor_overlay = _Volume3DCursorOverlay(
+            self._cursor_canvas_position,
+            self.orientation_indicator_mode,
+            self._orientation_canvas_positions,
+            self._orientation_widget_axes,
+            native,
+        )
+        self._view.scene.transform.changed.connect(
+            self._on_scene_transform_changed
         )
         if self.isVisible():
             QApplication.processEvents()
@@ -528,7 +863,18 @@ class Volume3DWidget(QWidget):
 
     def _destroy_canvas(self) -> None:
         self._release_active_visual()
-        for name in ("_patch_visual", "_source_box_visual", "_locator_visual"):
+        if self._view is not None:
+            self._view.scene.transform.changed.disconnect(
+                self._on_scene_transform_changed
+            )
+        if self._cursor_overlay is not None:
+            self._cursor_overlay.detach()
+            self._cursor_overlay = None
+        for name in (
+            "_patch_visual",
+            "_source_box_visual",
+            "_locator_visual",
+        ):
             visual = getattr(self, name)
             if visual is not None:
                 visual.parent = None
@@ -662,6 +1008,135 @@ class Volume3DWidget(QWidget):
             parent=self._view.scene,
         )
         self._request_canvas_update()
+
+    def _refresh_cursor_overlay(self) -> None:
+        if self._cursor_overlay is not None:
+            self._cursor_overlay.update()
+
+    def _cursor_canvas_position(self) -> tuple[float, float] | None:
+        if (
+            self._view is None
+            or not self._cursor_visible
+            or self._cursor_position is None
+            or self._volume_shape is None
+            or self._volume_affine is None
+        ):
+            return None
+        try:
+            centre = cursor_world_position(
+                self._cursor_position,
+                self._volume_shape,
+                self._volume_affine,
+            )
+        except ValueError:
+            return None
+        return self._world_canvas_position(centre)
+
+    def _world_canvas_position(
+        self,
+        world_position: np.ndarray,
+    ) -> tuple[float, float] | None:
+        if self._view is None:
+            return None
+        mapped = np.asarray(
+            self._view.scene.transform.map(world_position),
+            dtype=np.float64,
+        )
+        if mapped.shape != (4,) or not np.all(np.isfinite(mapped)):
+            return None
+        if abs(float(mapped[3])) <= np.finfo(np.float64).eps:
+            return None
+        return float(mapped[0] / mapped[3]), float(mapped[1] / mapped[3])
+
+    def _orientation_canvas_positions(
+        self,
+    ) -> tuple[tuple[str, float, float], ...]:
+        if (
+            self._view is None
+            or self._volume_shape is None
+            or self._volume_affine is None
+        ):
+            return ()
+        labels, world_positions = orientation_label_world_positions(
+            self._volume_shape,
+            self._volume_affine,
+        )
+        projected: list[tuple[str, float, float]] = []
+        for label, world_position in zip(labels, world_positions, strict=True):
+            canvas_position = self._world_canvas_position(world_position)
+            if canvas_position is not None:
+                projected.append(
+                    (label, canvas_position[0], canvas_position[1])
+                )
+        return tuple(projected)
+
+    def _orientation_widget_axes(
+        self,
+    ) -> tuple[tuple[str, float, float], ...]:
+        if (
+            self._view is None
+            or self._volume_shape is None
+            or self._volume_affine is None
+        ):
+            return ()
+        limits = _volume_world_limits(
+            self._volume_shape,
+            self._volume_affine,
+        )
+        world_center = np.asarray(
+            [
+                (minimum + maximum) / 2.0
+                for minimum, maximum in limits
+            ],
+            dtype=np.float64,
+        )
+        center_canvas = self._world_canvas_position(world_center)
+        if center_canvas is None:
+            return ()
+        world_span = max(
+            maximum - minimum
+            for minimum, maximum in limits
+        )
+        axis_step = max(float(world_span) * 0.12, 1.0e-3)
+        projected_axes: list[tuple[str, float, float]] = []
+        for axis, label in enumerate(("R", "A", "S")):
+            endpoint = world_center.copy()
+            endpoint[axis] += axis_step
+            endpoint_canvas = self._world_canvas_position(endpoint)
+            if endpoint_canvas is None:
+                continue
+            projected_axes.append(
+                (
+                    label,
+                    endpoint_canvas[0] - center_canvas[0],
+                    endpoint_canvas[1] - center_canvas[1],
+                )
+            )
+        if not projected_axes:
+            return ()
+        maximum_length = max(
+            float(np.hypot(direction_x, direction_y))
+            for _label, direction_x, direction_y in projected_axes
+        )
+        if maximum_length <= 1.0e-6:
+            return tuple(
+                (label, 0.0, 0.0)
+                for label, _direction_x, _direction_y in projected_axes
+            )
+        return tuple(
+            (
+                label,
+                direction_x / maximum_length,
+                direction_y / maximum_length,
+            )
+            for label, direction_x, direction_y in projected_axes
+        )
+
+    def _on_scene_transform_changed(self, _event: object = None) -> None:
+        self._refresh_cursor_overlay()
+
+    def _refresh_orientation_overlay(self) -> None:
+        self._refresh_cursor_overlay()
 
     def _refresh_locator_visual(self) -> None:
         if self._view is None:
@@ -804,6 +1279,48 @@ def _point_world_limits(
         (float(minimum[axis]), float(maximum[axis]))
         for axis in range(3)
     )
+
+
+def _pan_camera_with_middle_drag(camera: Any, event: Any) -> bool:
+    """Translate a VisPy turntable camera during an unmodified middle drag."""
+    if (
+        event.type != "mouse_move"
+        or event.press_event is None
+        or 3 not in event.buttons
+        or event.mouse_event.modifiers
+    ):
+        return False
+
+    press_position = np.asarray(event.mouse_event.press_event.pos, dtype=np.float64)
+    current_position = np.asarray(event.mouse_event.pos, dtype=np.float64)
+    view_size = np.asarray(camera._viewbox.size, dtype=np.float64)
+    normalization = float(np.mean(view_size))
+    if normalization <= 0.0:
+        return False
+    event_value = camera._event_value
+    if event_value is None or np.asarray(event_value).shape != (3,):
+        camera._event_value = tuple(float(value) for value in camera.center)
+
+    distance = (press_position - current_position) / normalization
+    distance *= float(camera._scale_factor)
+    distance[1] *= -1.0
+    delta_x, delta_y, delta_z = camera._dist_to_trans(distance)
+    flip_factors = camera._flip_factors
+    up, forward, right = camera._get_dim_vectors()
+    delta_x, delta_y, delta_z = (
+        right * delta_x + forward * delta_y + up * delta_z
+    )
+    delta_x = flip_factors[0] * delta_x
+    delta_y = flip_factors[1] * delta_y
+    delta_z = flip_factors[2] * delta_z
+    start_x, start_y, start_z = camera._event_value
+    camera.center = (
+        start_x + delta_x,
+        start_y + delta_y,
+        start_z + delta_z,
+    )
+    event.handled = True
+    return True
 
 
 def _require_pyopengl_3d_textures() -> None:

--- a/src/mipview/viewer/volume_3d_widget.py
+++ b/src/mipview/viewer/volume_3d_widget.py
@@ -41,6 +41,7 @@ from mipview.viewer.render_3d_preparation import (
     PreparedRender3D,
     cursor_world_position,
     orientation_label_world_positions,
+    patch_box_extension_world_segments,
     patch_box_world_segments,
     prepare_render,
     source_box_world_segments,
@@ -50,6 +51,7 @@ from mipview.viewer.render_3d_state import (
     SEGMENTATION_RENDER_MODES,
     Render3DSource,
     Render3DState,
+    render_mode_supports_mask,
 )
 
 
@@ -65,12 +67,14 @@ class _PreparationWorker(QRunnable):
         source: Render3DSource,
         render_mode: str,
         threshold: float,
+        mask_source: Render3DSource | None,
     ) -> None:
         super().__init__()
         self.token = token
         self.source = source
         self.render_mode = render_mode
         self.threshold = threshold
+        self.mask_source = mask_source
         self.signals = _PreparationSignals()
 
     @Slot()
@@ -81,6 +85,11 @@ class _PreparationWorker(QRunnable):
                 kind=self.source.kind,
                 render_mode=self.render_mode,
                 threshold=self.threshold,
+                mask_volume=(
+                    None
+                    if self.mask_source is None
+                    else self.mask_source.volume
+                ),
             )
         except Exception as exc:
             self.signals.failed.emit(self.token, str(exc))
@@ -329,6 +338,7 @@ class Volume3DWidget(QWidget):
         self._active_visual: Any | None = None
         self._prepared: PreparedRender3D | None = None
         self._patch_visual: Any | None = None
+        self._patch_extension_visual: Any | None = None
         self._source_box_visual: Any | None = None
         self._locator_visual: Any | None = None
         self._cursor_overlay: _Volume3DCursorOverlay | None = None
@@ -344,6 +354,7 @@ class Volume3DWidget(QWidget):
         self._locator_source_shape: tuple[int, int, int] | None = None
         self._locator_source_affine: np.ndarray | None = None
         self._patch_box = _PatchBoxState()
+        self._patch_extension_lines_visible = True
 
         self.title_label = QLabel("3D", self)
         self.title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
@@ -380,6 +391,7 @@ class Volume3DWidget(QWidget):
         panel.opacity_changed.connect(self.set_selected_opacity)
         panel.colour_changed.connect(self.set_selected_colour)
         panel.render_mode_changed.connect(self.set_selected_render_mode)
+        panel.mask_changed.connect(self.set_selected_mask_source)
         panel.threshold_changed.connect(self.set_selected_threshold)
         panel.update_requested.connect(self.update_selected_render)
         panel.reset_camera_requested.connect(self.reset_camera)
@@ -395,8 +407,27 @@ class Volume3DWidget(QWidget):
             if rendered_before is None
             else self.state.sources.get(rendered_before)
         )
+        previous_settings = (
+            None
+            if rendered_before is None
+            else self.state.settings.get(rendered_before)
+        )
+        previous_mask_id = (
+            None
+            if previous_settings is None
+            else previous_settings.mask_source_id
+        )
+        previous_mask_source = (
+            None
+            if previous_mask_id is None
+            else self.state.sources.get(previous_mask_id)
+        )
         replacement_source = next(
             (source for source in sources if source.id == rendered_before),
+            None,
+        )
+        replacement_mask_source = next(
+            (source for source in sources if source.id == previous_mask_id),
             None,
         )
         self.state.set_sources(sources)
@@ -405,11 +436,26 @@ class Volume3DWidget(QWidget):
             and replacement_source is not None
             and previous_source.volume is not replacement_source.volume
         )
+        mask_data_changed = (
+            previous_mask_source is not None
+            and previous_source is not None
+            and previous_settings is not None
+            and render_mode_supports_mask(
+                previous_source.kind,
+                previous_settings.render_mode,
+            )
+            and (
+                replacement_mask_source is None
+                or previous_mask_source.volume
+                is not replacement_mask_source.volume
+            )
+        )
         if (
             rendered_before is not None
             and (
                 self.state.rendered_source_id is None
                 or source_data_changed
+                or mask_data_changed
             )
         ):
             self._release_active_visual()
@@ -504,6 +550,14 @@ class Volume3DWidget(QWidget):
             source,
             settings.render_mode,
             settings.threshold,
+            (
+                self.state.selected_mask_source()
+                if render_mode_supports_mask(
+                    source.kind,
+                    settings.render_mode,
+                )
+                else None
+            ),
         )
         self._workers[token] = worker
         worker.signals.finished.connect(self._on_preparation_finished)
@@ -561,6 +615,36 @@ class Volume3DWidget(QWidget):
                 )
             settings.render_mode = render_mode
             settings.dirty = True
+            self._sync_panel_settings()
+        if self._panel is not None:
+            self._panel.set_status("Update required.")
+        self._emit_state()
+
+    def set_selected_mask_source(self, mask_source_id: object) -> None:
+        settings = self.state.selected_settings()
+        if settings is None:
+            return
+        normalized = mask_source_id if isinstance(mask_source_id, str) else None
+        compatible_ids = {
+            source.id
+            for source in self.state.compatible_masks_for(
+                self.state.selected_source_id
+            )
+        }
+        if normalized is not None and normalized not in compatible_ids:
+            self._set_error(
+                "3D render mask is unavailable or spatially incompatible: "
+                f"{normalized}"
+            )
+            return
+        if settings.mask_source_id != normalized:
+            if self.state.busy:
+                self._cancel_pending_preparation(
+                    "3D render mask changed; click Update."
+                )
+            settings.mask_source_id = normalized
+            settings.dirty = True
+            self._sync_panel_settings()
         if self._panel is not None:
             self._panel.set_status("Update required.")
         self._emit_state()
@@ -659,6 +743,16 @@ class Volume3DWidget(QWidget):
         )
         self._refresh_patch_visual()
 
+    def set_patch_extension_lines_visible(self, visible: bool) -> None:
+        normalized = bool(visible)
+        if normalized == self._patch_extension_lines_visible:
+            return
+        self._patch_extension_lines_visible = normalized
+        self._refresh_patch_visual()
+
+    def patch_extension_lines_visible(self) -> bool:
+        return self._patch_extension_lines_visible
+
     def set_volume_geometry(
         self,
         shape: tuple[int, int, int] | None,
@@ -684,6 +778,7 @@ class Volume3DWidget(QWidget):
                 )
             self._volume_shape = normalized_shape
             self._volume_affine = normalized_affine
+        self._refresh_patch_visual()
         self._refresh_cursor_overlay()
         self._refresh_orientation_overlay()
 
@@ -731,6 +826,8 @@ class Volume3DWidget(QWidget):
         self._locator_volume = volume
         self._locator_visible = bool(visible)
         self._refresh_locator_visual()
+        self._refresh_patch_visual()
+        self._refresh_orientation_overlay()
 
     def set_locator_source_extent(
         self,
@@ -742,11 +839,16 @@ class Volume3DWidget(QWidget):
             None if affine is None else np.asarray(affine, dtype=np.float64)
         )
         self._refresh_locator_visual()
+        self._refresh_patch_visual()
+        self._refresh_orientation_overlay()
 
     def status(self) -> dict[str, object]:
         status = self.state.status()
         status["locator_visible"] = self._locator_visible
         status["patch_box_visible"] = self._patch_box.visible
+        status["patch_extension_lines_visible"] = (
+            self._patch_extension_lines_visible
+        )
         status["cursor_visible"] = self._cursor_visible
         status["cursor_position"] = (
             None
@@ -872,6 +974,7 @@ class Volume3DWidget(QWidget):
             self._cursor_overlay = None
         for name in (
             "_patch_visual",
+            "_patch_extension_visual",
             "_source_box_visual",
             "_locator_visual",
         ):
@@ -917,11 +1020,18 @@ class Volume3DWidget(QWidget):
                 prepared.data,
                 method=method,
                 clim=(0, 255),
+                interpolation=(
+                    "nearest" if prepared.mask_applied else "linear"
+                ),
                 cmap=_volume_colormap(
                     settings.colour,
                     settings.opacity,
                     translucent=method == "translucent",
                     cutoff=cutoff,
+                    masked_minip=(
+                        prepared.mask_applied
+                        and prepared.render_mode == "MinIP"
+                    ),
                 ),
                 parent=self._view.scene,
             )
@@ -975,6 +1085,10 @@ class Volume3DWidget(QWidget):
                 settings.opacity,
                 translucent=self._prepared.render_mode == "Translucent",
                 cutoff=cutoff,
+                masked_minip=(
+                    self._prepared.mask_applied
+                    and self._prepared.render_mode == "MinIP"
+                ),
             )
         elif self._prepared.render_mode == "Points":
             self._active_visual.set_data(
@@ -990,24 +1104,108 @@ class Volume3DWidget(QWidget):
     def _refresh_patch_visual(self) -> None:
         if self._view is None:
             return
-        if self._patch_visual is not None:
-            self._patch_visual.parent = None
-            self._patch_visual = None
         state = self._patch_box
         if not state.visible or state.bounds is None or state.affine is None:
+            self._remove_patch_visuals()
             self._request_canvas_update()
             return
         from vispy import scene
 
         segments = patch_box_world_segments(state.bounds, state.affine)
-        self._patch_visual = scene.visuals.Line(
-            pos=segments,
-            connect="segments",
-            color=(1.0, 0.85, 0.05, 1.0),
-            width=2.5,
-            parent=self._view.scene,
-        )
+        if self._patch_visual is None:
+            self._patch_visual = scene.visuals.Line(
+                pos=segments,
+                connect="segments",
+                color=(1.0, 0.85, 0.05, 1.0),
+                width=2.5,
+                parent=self._view.scene,
+            )
+        else:
+            self._patch_visual.set_data(
+                pos=segments,
+                connect="segments",
+            )
+        extension_geometry = self._source_context_geometry()
+        if (
+            self._patch_extension_lines_visible
+            and extension_geometry is not None
+        ):
+            source_shape, source_affine = extension_geometry
+            bounds_within_source = (
+                0 <= state.bounds.x_start < state.bounds.x_end <= source_shape[0]
+                and 0
+                <= state.bounds.y_start
+                < state.bounds.y_end
+                <= source_shape[1]
+                and 0
+                <= state.bounds.z_start
+                < state.bounds.z_end
+                <= source_shape[2]
+            )
+            affines_match = np.allclose(
+                state.affine,
+                source_affine,
+                atol=1.0e-4,
+                rtol=0.0,
+            )
+            extension_segments = (
+                patch_box_extension_world_segments(
+                    state.bounds,
+                    source_shape,
+                    source_affine,
+                )
+                if bounds_within_source and affines_match
+                else np.empty((0, 3), dtype=np.float32)
+            )
+            if extension_segments.size:
+                if self._patch_extension_visual is None:
+                    self._patch_extension_visual = scene.visuals.Line(
+                        pos=extension_segments,
+                        connect="segments",
+                        color=(1.0, 0.85, 0.05, 0.9),
+                        width=1.0,
+                        parent=self._view.scene,
+                    )
+                else:
+                    self._patch_extension_visual.set_data(
+                        pos=extension_segments,
+                        connect="segments",
+                    )
+            elif self._patch_extension_visual is not None:
+                self._patch_extension_visual.parent = None
+                self._patch_extension_visual = None
+        elif self._patch_extension_visual is not None:
+            self._patch_extension_visual.parent = None
+            self._patch_extension_visual = None
         self._request_canvas_update()
+
+    def _remove_patch_visuals(self) -> None:
+        for name in ("_patch_visual", "_patch_extension_visual"):
+            visual = getattr(self, name)
+            if visual is not None:
+                visual.parent = None
+                setattr(self, name, None)
+
+    def _source_context_geometry(
+        self,
+    ) -> tuple[tuple[int, int, int], np.ndarray] | None:
+        if self._locator_visible:
+            if self._locator_volume is not None:
+                return (
+                    tuple(int(value) for value in self._locator_volume.shape),
+                    np.asarray(self._locator_volume.affine, dtype=np.float64),
+                )
+            if (
+                self._locator_source_shape is not None
+                and self._locator_source_affine is not None
+            ):
+                return (
+                    tuple(int(value) for value in self._locator_source_shape),
+                    self._locator_source_affine,
+                )
+        if self._volume_shape is None or self._volume_affine is None:
+            return None
+        return self._volume_shape, self._volume_affine
 
     def _refresh_cursor_overlay(self) -> None:
         if self._cursor_overlay is not None:
@@ -1051,15 +1249,13 @@ class Volume3DWidget(QWidget):
     def _orientation_canvas_positions(
         self,
     ) -> tuple[tuple[str, float, float], ...]:
-        if (
-            self._view is None
-            or self._volume_shape is None
-            or self._volume_affine is None
-        ):
+        geometry = self._source_context_geometry()
+        if self._view is None or geometry is None:
             return ()
+        shape, affine = geometry
         labels, world_positions = orientation_label_world_positions(
-            self._volume_shape,
-            self._volume_affine,
+            shape,
+            affine,
         )
         projected: list[tuple[str, float, float]] = []
         for label, world_position in zip(labels, world_positions, strict=True):
@@ -1073,15 +1269,13 @@ class Volume3DWidget(QWidget):
     def _orientation_widget_axes(
         self,
     ) -> tuple[tuple[str, float, float], ...]:
-        if (
-            self._view is None
-            or self._volume_shape is None
-            or self._volume_affine is None
-        ):
+        geometry = self._source_context_geometry()
+        if self._view is None or geometry is None:
             return ()
+        shape, affine = geometry
         limits = _volume_world_limits(
-            self._volume_shape,
-            self._volume_affine,
+            shape,
+            affine,
         )
         world_center = np.asarray(
             [
@@ -1211,11 +1405,22 @@ class Volume3DWidget(QWidget):
         source = self.state.selected_source()
         settings = self.state.selected_settings()
         if source is None or settings is None:
+            self._panel.set_modes((), "")
+            self._panel.set_masks((), None)
             self._panel.set_status("Load an image before rendering.")
             self._panel.set_render_controls_enabled(False)
             return
         modes = RAW_RENDER_MODES if source.kind == "image" else SEGMENTATION_RENDER_MODES
         self._panel.set_modes(modes, settings.render_mode)
+        self._panel.set_masks(
+            [
+                (mask_source.id, mask_source.display_name)
+                for mask_source in self.state.compatible_masks_for(
+                    self.state.selected_source_id
+                )
+            ],
+            settings.mask_source_id,
+        )
         self._panel.set_settings(settings)
         self._panel.set_render_controls_enabled(self.state.active)
 
@@ -1341,6 +1546,7 @@ def _volume_colormap(
     *,
     translucent: bool = False,
     cutoff: float = 0.0,
+    masked_minip: bool = False,
 ) -> Any:
     from vispy.color import Colormap
 
@@ -1368,6 +1574,15 @@ def _volume_colormap(
                 (red, green, blue, alpha * 0.25),
             ],
             controls=[0.0, lower, middle, 1.0],
+        )
+    if masked_minip:
+        return Colormap(
+            [
+                (0.0, 0.0, 0.0, 0.0),
+                (red, green, blue, alpha),
+                (red, green, blue, 0.0),
+            ],
+            controls=[0.0, 254.0 / 255.0, 1.0],
         )
     return Colormap(
         [

--- a/src/mipview/viewer/volume_3d_widget.py
+++ b/src/mipview/viewer/volume_3d_widget.py
@@ -44,14 +44,21 @@ from mipview.viewer.render_3d_preparation import (
     patch_box_extension_world_segments,
     patch_box_world_segments,
     prepare_render,
+    prepare_vessel_graph_render,
     source_box_world_segments,
 )
 from mipview.viewer.render_3d_state import (
     RAW_RENDER_MODES,
     SEGMENTATION_RENDER_MODES,
+    VESSEL_GRAPH_RENDER_MODES,
     Render3DSource,
     Render3DState,
     render_mode_supports_mask,
+)
+from mipview.vessel_graph.model import (
+    PROJECTED_INTERCEPT_COLOR,
+    VESSEL_EDGE_COLOR,
+    VESSEL_NODE_COLOR,
 )
 
 
@@ -80,17 +87,24 @@ class _PreparationWorker(QRunnable):
     @Slot()
     def run(self) -> None:
         try:
-            prepared = prepare_render(
-                self.source.volume,
-                kind=self.source.kind,
-                render_mode=self.render_mode,
-                threshold=self.threshold,
-                mask_volume=(
-                    None
-                    if self.mask_source is None
-                    else self.mask_source.volume
-                ),
-            )
+            if self.source.kind == "vessel_graph":
+                if self.source.vessel_graph is None:
+                    raise ValueError("Vessel graph render geometry is unavailable.")
+                prepared = prepare_vessel_graph_render(self.source.vessel_graph)
+            else:
+                if self.source.volume is None:
+                    raise ValueError("NIfTI render volume is unavailable.")
+                prepared = prepare_render(
+                    self.source.volume,
+                    kind=self.source.kind,
+                    render_mode=self.render_mode,
+                    threshold=self.threshold,
+                    mask_volume=(
+                        None
+                        if self.mask_source is None
+                        else self.mask_source.volume
+                    ),
+                )
         except Exception as exc:
             self.signals.failed.emit(self.token, str(exc))
             return
@@ -336,6 +350,7 @@ class Volume3DWidget(QWidget):
         self._canvas: Any | None = None
         self._view: Any | None = None
         self._active_visual: Any | None = None
+        self._active_graph_visuals: dict[str, Any] = {}
         self._prepared: PreparedRender3D | None = None
         self._patch_visual: Any | None = None
         self._patch_extension_visual: Any | None = None
@@ -387,8 +402,13 @@ class Volume3DWidget(QWidget):
         self._panel = panel
         panel.activation_requested.connect(self.set_active)
         panel.source_changed.connect(self.select_source)
-        panel.visibility_changed.connect(self.set_selected_visibility)
         panel.opacity_changed.connect(self.set_selected_opacity)
+        panel.vessel_graph_node_size_changed.connect(
+            self.set_selected_node_size
+        )
+        panel.vessel_graph_edge_thickness_changed.connect(
+            self.set_selected_edge_thickness
+        )
         panel.colour_changed.connect(self.set_selected_colour)
         panel.render_mode_changed.connect(self.set_selected_render_mode)
         panel.mask_changed.connect(self.set_selected_mask_source)
@@ -434,7 +454,11 @@ class Volume3DWidget(QWidget):
         source_data_changed = (
             previous_source is not None
             and replacement_source is not None
-            and previous_source.volume is not replacement_source.volume
+            and (
+                previous_source.volume is not replacement_source.volume
+                or previous_source.vessel_graph
+                is not replacement_source.vessel_graph
+            )
         )
         mask_data_changed = (
             previous_mask_source is not None
@@ -600,12 +624,38 @@ class Volume3DWidget(QWidget):
         self._apply_active_style()
         self._emit_state()
 
+    def set_selected_node_size(self, node_size: int) -> None:
+        settings = self.state.selected_settings()
+        if settings is None:
+            return
+        settings.set_node_size(node_size)
+        self._apply_active_style()
+        self._sync_panel_settings()
+        self._emit_state()
+
+    def set_selected_edge_thickness(self, edge_thickness: int) -> None:
+        settings = self.state.selected_settings()
+        if settings is None:
+            return
+        settings.set_edge_thickness(edge_thickness)
+        self._apply_active_style()
+        self._sync_panel_settings()
+        self._emit_state()
+
     def set_selected_render_mode(self, render_mode: str) -> None:
         source = self.state.selected_source()
         settings = self.state.selected_settings()
         if source is None or settings is None:
             return
-        allowed = RAW_RENDER_MODES if source.kind == "image" else SEGMENTATION_RENDER_MODES
+        allowed = (
+            RAW_RENDER_MODES
+            if source.kind == "image"
+            else (
+                SEGMENTATION_RENDER_MODES
+                if source.kind == "segmentation"
+                else VESSEL_GRAPH_RENDER_MODES
+            )
+        )
         if render_mode not in allowed:
             return
         if settings.render_mode != render_mode:
@@ -727,6 +777,17 @@ class Volume3DWidget(QWidget):
             )
         if prepared.vertices is not None and prepared.vertices.size:
             return _point_world_limits(prepared.vertices)
+        graph_points = [
+            points
+            for points in (
+                prepared.graph_edge_segments,
+                prepared.graph_node_positions,
+                prepared.graph_intercept_positions,
+            )
+            if points is not None and points.size
+        ]
+        if graph_points:
+            return _point_world_limits(np.concatenate(graph_points, axis=0))
         return None
 
     def set_patch_box(
@@ -995,6 +1056,7 @@ class Volume3DWidget(QWidget):
         if self._active_visual is not None:
             self._active_visual.parent = None
         self._active_visual = None
+        self._active_graph_visuals = {}
         self._prepared = None
 
     def _create_visual(self, prepared: PreparedRender3D, settings: Any) -> Any:
@@ -1004,7 +1066,45 @@ class Volume3DWidget(QWidget):
         from vispy.visuals.transforms import MatrixTransform
 
         rgba = _rgba(settings.colour, settings.opacity)
-        if prepared.kind == "image":
+        if prepared.kind == "vessel_graph":
+            parent = scene.Node(parent=self._view.scene)
+            if (
+                prepared.graph_edge_segments is not None
+                and prepared.graph_edge_segments.size
+            ):
+                self._active_graph_visuals["edges"] = scene.visuals.Line(
+                    pos=prepared.graph_edge_segments,
+                    connect="segments",
+                    color=_rgba(VESSEL_EDGE_COLOR, settings.opacity),
+                    width=float(settings.edge_thickness),
+                    parent=parent,
+                )
+            if (
+                prepared.graph_node_positions is not None
+                and prepared.graph_node_positions.size
+            ):
+                nodes = scene.visuals.Markers(parent=parent)
+                nodes.set_data(
+                    prepared.graph_node_positions,
+                    face_color=_rgba(VESSEL_NODE_COLOR, settings.opacity),
+                    edge_width=0,
+                    size=float(settings.node_size * 2),
+                )
+                self._active_graph_visuals["nodes"] = nodes
+            if (
+                prepared.graph_intercept_positions is not None
+                and prepared.graph_intercept_positions.size
+            ):
+                intercepts = scene.visuals.Markers(parent=parent)
+                intercepts.set_data(
+                    prepared.graph_intercept_positions,
+                    face_color=_rgba(PROJECTED_INTERCEPT_COLOR, settings.opacity),
+                    edge_width=0,
+                    size=float(settings.node_size * 2),
+                )
+                self._active_graph_visuals["intercepts"] = intercepts
+            visual = parent
+        elif prepared.kind == "image":
             _require_pyopengl_3d_textures()
             method = {
                 "MIP": "mip",
@@ -1075,7 +1175,35 @@ class Volume3DWidget(QWidget):
         if settings is None:
             return
         rgba = _rgba(settings.colour, settings.opacity)
-        if self._prepared.kind == "image":
+        if self._prepared.kind == "vessel_graph":
+            edges = self._active_graph_visuals.get("edges")
+            if edges is not None:
+                edges.set_data(
+                    pos=self._prepared.graph_edge_segments,
+                    connect="segments",
+                    color=_rgba(VESSEL_EDGE_COLOR, settings.opacity),
+                    width=float(settings.edge_thickness),
+                )
+            nodes = self._active_graph_visuals.get("nodes")
+            if nodes is not None:
+                nodes.set_data(
+                    self._prepared.graph_node_positions,
+                    face_color=_rgba(VESSEL_NODE_COLOR, settings.opacity),
+                    edge_width=0,
+                    size=float(settings.node_size * 2),
+                )
+            intercepts = self._active_graph_visuals.get("intercepts")
+            if intercepts is not None:
+                intercepts.set_data(
+                    self._prepared.graph_intercept_positions,
+                    face_color=_rgba(
+                        PROJECTED_INTERCEPT_COLOR,
+                        settings.opacity,
+                    ),
+                    edge_width=0,
+                    size=float(settings.node_size * 2),
+                )
+        elif self._prepared.kind == "image":
             cutoff = _normalized_threshold(
                 settings.threshold,
                 self._prepared.source_range,
@@ -1405,12 +1533,22 @@ class Volume3DWidget(QWidget):
         source = self.state.selected_source()
         settings = self.state.selected_settings()
         if source is None or settings is None:
+            self._panel.set_source_kind(None)
             self._panel.set_modes((), "")
             self._panel.set_masks((), None)
             self._panel.set_status("Load an image before rendering.")
             self._panel.set_render_controls_enabled(False)
             return
-        modes = RAW_RENDER_MODES if source.kind == "image" else SEGMENTATION_RENDER_MODES
+        modes = (
+            RAW_RENDER_MODES
+            if source.kind == "image"
+            else (
+                SEGMENTATION_RENDER_MODES
+                if source.kind == "segmentation"
+                else VESSEL_GRAPH_RENDER_MODES
+            )
+        )
+        self._panel.set_source_kind(source.kind)
         self._panel.set_modes(modes, settings.render_mode)
         self._panel.set_masks(
             [


### PR DESCRIPTION
- Added read-only GraphML vessel-graph support for main and patch 3D viewers.
- Added patch-clipped GraphML projections in MIP/MinIP views:
              - Red: original nodes
              - Green: vessel edges
              - Blue: patch-boundary intersections
- Added affine-aware GraphML/NIfTI coordinate conversion and spatial validation. Mismatched graphs remain loaded in warning mode, with unsafe patch projection disabled.
- Added multiple GraphML loading, GraphML drag-and-drop, and import-only graph3d.* control commands.
- Separated editable 2D .mipgraph.json graphs from read-only 3D .graphml graphs.
- Revised graph controls:
              - Conditional Vessel Graph subsection in 3D Volume
              - 2D Graph (only available on MIP/MinIP) panel
              - Independent GraphML projection selection
              - Mutually exclusive created and projected graphs
              - Synchronized node size and edge thickness
              - Independent 2D and 3D opacity
- Added segmentation-mask-aware 3D MIP/MinIP, Surface, and Points rendering.
- Added anatomical orientation labels/widget modes across 2D and 3D viewers.
- Preserved original NIfTI geometry and voxel-coordinate provenance through loading and derived-volume operations.
- Renamed MIP the segmentation to MIP The Overlay and clarified graph creation/save/load labels.
- Interface preview:
<img width="2518" height="1320" alt="image" src="https://github.com/user-attachments/assets/742ea6f5-dd87-4a18-b0d3-df49fe2fe99f" />
