### PR TITLE
V0.6.0: Add overlay support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tests/*.py
 test_data/
 
 debug.ipynb
+/CHECKLIST.md
 
 AGENTS.md
 refs/

--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ The optional 3D viewer uses VisPy with its PySide6 backend and PyOpenGL for
 raw-volume texture uploads. A working OpenGL implementation is also required.
 If 3D rendering is unavailable, the orthogonal viewers remain usable and the
 **3D Volume** toolbox reports an actionable error.
+The main and patch 3D viewers support one independent overlay in addition to
+the base render. Overlay choices are limited to loaded file-backed NIfTI
+segmentations and loaded GraphML vessel graphs; unsaved annotations and
+additional scalar image volumes are not offered. NIfTI overlays must retain
+the source shape and affine, are never resampled automatically, and use
+editable deterministic per-label colours. GraphML overlays retain their
+semantic edge, node, and intercept colours. Base and overlay renders are
+prepared independently and alpha-composited with the overlay drawn last. The
+base-pass depth buffer is reset before the overlay pass so ray-cast scalar
+volume proxy geometry cannot clip overlays located inside the volume.
 Camera framing uses affine-scaled world bounds so raw textures and foreground
 meshes open at the same physical scale and default viewing angle.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mipview"
-version = "0.5.7"
+version = "0.6.0"
 description = "A lightweight Linux-first NIfTI viewer for patch-based inspection workflows."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/mipview/control/README.md
+++ b/src/mipview/control/README.md
@@ -483,18 +483,45 @@ mipview-ctl render3d update
 mipview-ctl render3d reset-camera
 mipview-ctl render3d dismiss
 
+mipview-ctl render3d select SEGMENTATION_ID --layer overlay
+mipview-ctl render3d display --layer overlay --opacity 0.5 --mode Surface
+mipview-ctl render3d display --layer overlay --label-colour 1 255 64 64
+mipview-ctl render3d update --layer overlay
+mipview-ctl render3d dismiss --layer overlay
+mipview-ctl render3d activate --layer overlay
+
 mipview-ctl render3d status --session-id SESSION_ID
 mipview-ctl patch display-location SESSION_ID show
 ```
 
 `render3d display` accepts `--visible` / `--no-visible`, `--opacity`,
-`--colour R G B`, `--mode`, `--mask`, `--no-mask`, and `--threshold`. Masks
+`--colour R G B`, `--label-colour LABEL R G B`, `--mode`, `--mask`,
+`--no-mask`, and `--threshold`. Every `render3d` command accepts
+`--layer base|overlay`; omitting it preserves the existing base-layer
+behaviour.
+
+The overlay role supports exactly one file-backed loaded NIfTI segmentation or
+GraphML layer and excludes the selected base source. Selecting or changing the
+overlay marks it for update, and `render3d update --layer overlay` prepares and
+displays it automatically. Selecting `---` clears the overlay choice. Main and patch
+windows retain independent 3D overlay settings, and neither selection follows
+the active 2D orthogonal overlay.
+
+Masks
 include all nonzero voxels and must be loaded,
 spatially compatible segmentation layers. Masking applies to image MIP/MinIP
 and segmentation Surface/Points modes; it is ignored for image Translucent and
-Isosurface modes. Exactly one selected NIfTI file is rendered at a time.
-Dismissing the view releases its VisPy canvas and GPU resources.
-`render3d.status` reports the selected and rendered source IDs, selected mask,
+Isosurface modes and is unavailable for GraphML. Segmentation Surface and
+Points rendering requires finite, non-negative integer labels, supports up to
+256 foreground labels, and uses editable deterministic per-label colours.
+Overlay rendering is prepared independently and alpha-composited after the
+base render.
+
+Dismissing the base view releases its VisPy canvas and both layers. For the
+overlay role, `dismiss` hides the prepared visual and `activate` shows it again
+without recomputation; the selected source, prepared data, and settings are
+retained. `render3d.status` reports the selected and rendered source
+IDs, selected mask,
 whether that mask applies to the current mode, busy/update-required state,
 prepared shape, downsampling stride, locator state, and the last renderer error.
 

--- a/src/mipview/control/cli.py
+++ b/src/mipview/control/cli.py
@@ -256,11 +256,27 @@ def _build_parser() -> argparse.ArgumentParser:
             default=None,
             help="Optional patch-window session; omit for the main window.",
         )
+        command_parser.add_argument(
+            "--layer",
+            choices=("base", "overlay"),
+            default="base",
+            help="Target the base render or the independent 3D overlay.",
+        )
     render_select = render_subparsers.add_parser("select")
     render_select.add_argument("source_id")
     render_select.add_argument("--session-id", default=None)
+    render_select.add_argument(
+        "--layer",
+        choices=("base", "overlay"),
+        default="base",
+    )
     render_display = render_subparsers.add_parser("display")
     render_display.add_argument("--session-id", default=None)
+    render_display.add_argument(
+        "--layer",
+        choices=("base", "overlay"),
+        default="base",
+    )
     render_display.add_argument(
         "--visible",
         action=argparse.BooleanOptionalAction,
@@ -268,6 +284,13 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     render_display.add_argument("--opacity", type=float, default=None)
     render_display.add_argument("--colour", type=int, nargs=3, default=None)
+    render_display.add_argument(
+        "--label-colour",
+        type=int,
+        nargs=4,
+        metavar=("LABEL", "R", "G", "B"),
+        default=None,
+    )
     render_display.add_argument("--mode", default=None)
     render_mask_group = render_display.add_mutually_exclusive_group()
     render_mask_group.add_argument(
@@ -718,7 +741,10 @@ def _command_from_args(args: argparse.Namespace) -> tuple[str, dict[str, Any], A
             )
 
     if args.group == "render3d":
-        common = {"session_id": args.session_id}
+        common = {
+            "session_id": args.session_id,
+            "layer": args.layer,
+        }
         if args.render3d_command == "status":
             return "render3d.status", common, None
         if args.render3d_command in {"activate", "dismiss"}:
@@ -748,6 +774,7 @@ def _command_from_args(args: argparse.Namespace) -> tuple[str, dict[str, Any], A
                 "colour": args.colour,
                 "render_mode": args.mode,
                 "threshold": args.threshold,
+                "label_colour": args.label_colour,
             }
             if args.mask is not None:
                 display_args["mask_source_id"] = args.mask

--- a/src/mipview/control/controller.py
+++ b/src/mipview/control/controller.py
@@ -22,6 +22,9 @@ from mipview.patch.selector import PatchBounds
 from mipview.viewer.intensity import normalize_slice_to_uint8
 from mipview.viewer.oriented_volume import build_oriented_volume
 from mipview.viewer.render_3d_state import (
+    RENDER_LAYER_BASE,
+    RENDER_LAYER_OVERLAY,
+    RENDER_LAYERS,
     RAW_RENDER_MODES,
     SEGMENTATION_RENDER_MODES,
     VESSEL_GRAPH_RENDER_MODES,
@@ -33,6 +36,15 @@ from mipview.viewer.slice_geometry import project_oriented_volume
 SUPPORTED_ORIENTATIONS: set[str] = {"axial", "coronal", "sagittal"}
 SUPPORTED_PROJECTION_MODES: set[str] = {"MIP", "MINIP"}
 _UNSET = object()
+
+
+def _validate_render3d_layer(layer: str) -> CommandResult | None:
+    if layer in RENDER_LAYERS:
+        return None
+    return CommandResult(
+        False,
+        f"3D render layer must be one of: {', '.join(RENDER_LAYERS)}.",
+    )
 
 
 class MipViewController:
@@ -121,22 +133,42 @@ class MipViewController:
 
         return CommandResult(True, "Viewer state exported.", data)
 
-    def get_render3d_status(self, session_id: str | None = None) -> CommandResult:
+    def get_render3d_status(
+        self,
+        session_id: str | None = None,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> CommandResult:
+        invalid_layer = _validate_render3d_layer(layer)
+        if invalid_layer is not None:
+            return invalid_layer
         target = self._render3d_target(session_id)
         if isinstance(target, CommandResult):
             return target
-        return CommandResult(True, "3D render status exported.", target.status())
+        return CommandResult(
+            True,
+            f"3D {layer} render status exported.",
+            target.state.layer_status(layer),
+        )
 
     def set_render3d_active(
         self,
         active: bool,
         session_id: str | None = None,
+        layer: str = RENDER_LAYER_BASE,
     ) -> CommandResult:
+        invalid_layer = _validate_render3d_layer(layer)
+        if invalid_layer is not None:
+            return invalid_layer
         target = self._render3d_target(session_id)
         if isinstance(target, CommandResult):
             return target
-        target.set_active(bool(active))
-        status = target.status()
+        if layer == RENDER_LAYER_BASE:
+            target.set_active(bool(active))
+        elif active:
+            target.set_overlay_active(True)
+        else:
+            target.dismiss_overlay()
+        status = target.state.layer_status(layer)
         if bool(active) and not status["active"]:
             return CommandResult(
                 False,
@@ -145,41 +177,89 @@ class MipViewController:
             )
         return CommandResult(
             True,
-            "3D view activated." if active else "3D resources released.",
+            (
+                (
+                    "3D overlay shown."
+                    if layer == RENDER_LAYER_OVERLAY
+                    else "3D base activated."
+                )
+                if active
+                else (
+                    "3D overlay hidden."
+                    if layer == RENDER_LAYER_OVERLAY
+                    else "3D base resources released."
+                )
+            ),
             status,
         )
 
     def select_render3d_source(
         self,
-        source_id: str,
+        source_id: str | None,
         session_id: str | None = None,
+        layer: str = RENDER_LAYER_BASE,
     ) -> CommandResult:
+        invalid_layer = _validate_render3d_layer(layer)
+        if invalid_layer is not None:
+            return invalid_layer
         target = self._render3d_target(session_id)
         if isinstance(target, CommandResult):
             return target
-        normalized = str(source_id)
-        if normalized not in target.state.sources:
+        normalized = (
+            None
+            if source_id in {None, "---"}
+            else str(source_id)
+        )
+        eligible_ids = (
+            set(target.state.sources)
+            if layer == RENDER_LAYER_BASE
+            else {source.id for source in target.state.overlay_sources()}
+        )
+        if normalized is not None and normalized not in eligible_ids:
             return CommandResult(
                 False,
-                f"3D layer does not exist: {normalized}",
+                f"3D {layer} layer does not exist or is ineligible: {normalized}",
             )
-        target.select_source(normalized)
-        return CommandResult(True, "3D layer selected.", target.status())
+        target.select_source(normalized, layer)
+        return CommandResult(
+            True,
+            f"3D {layer} layer selected.",
+            target.state.layer_status(layer),
+        )
 
     def update_render3d(
         self,
         session_id: str | None = None,
+        layer: str = RENDER_LAYER_BASE,
     ) -> CommandResult:
+        invalid_layer = _validate_render3d_layer(layer)
+        if invalid_layer is not None:
+            return invalid_layer
         target = self._render3d_target(session_id)
         if isinstance(target, CommandResult):
             return target
-        if target.state.selected_source() is None:
-            return CommandResult(False, "No NIfTI layer is available for 3D rendering.")
-        target.update_selected_render()
-        status = target.status()
+        if target.state.selected_source(layer) is None:
+            return CommandResult(
+                False,
+                f"No {layer} layer is available for 3D rendering.",
+            )
+        if (
+            layer == RENDER_LAYER_OVERLAY
+            and target.state.rendered_source_id is None
+        ):
+            return CommandResult(
+                False,
+                "Render the base 3D layer before updating the overlay.",
+            )
+        target.update_selected_render(layer)
+        status = target.state.layer_status(layer)
         if status["last_error"] is not None and not status["busy"]:
             return CommandResult(False, str(status["last_error"]), status)
-        return CommandResult(True, "3D render update started.", status)
+        return CommandResult(
+            True,
+            f"3D {layer} render update started.",
+            status,
+        )
 
     def set_render3d_display(
         self,
@@ -191,11 +271,16 @@ class MipViewController:
         render_mode: str | None = None,
         threshold: float | None = None,
         mask_source_id: object = _UNSET,
+        label_colour: list[int] | tuple[int, int, int, int] | None = None,
+        layer: str = RENDER_LAYER_BASE,
     ) -> CommandResult:
+        invalid_layer = _validate_render3d_layer(layer)
+        if invalid_layer is not None:
+            return invalid_layer
         target = self._render3d_target(session_id)
         if isinstance(target, CommandResult):
             return target
-        if target.state.selected_source() is None:
+        if target.state.selected_source(layer) is None:
             return CommandResult(False, "No 3D layer is selected.")
         if opacity is not None and not 0.0 <= float(opacity) <= 1.0:
             return CommandResult(False, "3D opacity must be between 0.0 and 1.0.")
@@ -204,7 +289,7 @@ class MipViewController:
         ):
             return CommandResult(False, "3D colour must contain three values in 0..255.")
         if render_mode is not None:
-            source = target.state.selected_source()
+            source = target.state.selected_source(layer)
             allowed_modes = (
                 RAW_RENDER_MODES
                 if source is not None and source.kind == "image"
@@ -234,7 +319,11 @@ class MipViewController:
             compatible_ids = {
                 source.id
                 for source in target.state.compatible_masks_for(
-                    target.state.selected_source_id
+                    (
+                        target.state.selected_source_id
+                        if layer == RENDER_LAYER_BASE
+                        else target.state.overlay_selected_source_id
+                    )
                 )
             }
             if (
@@ -246,31 +335,70 @@ class MipViewController:
                     "3D render mask must be a loaded, spatially compatible "
                     f"segmentation layer: {normalized_mask_id}",
                 )
+        if label_colour is not None:
+            if len(label_colour) != 4:
+                return CommandResult(
+                    False,
+                    "3D label colour must contain LABEL R G B.",
+                )
+            label_value, *rgb = (int(value) for value in label_colour)
+            if label_value <= 0 or any(not 0 <= value <= 255 for value in rgb):
+                return CommandResult(
+                    False,
+                    "3D label colour requires a positive label and RGB values in 0..255.",
+                )
+            source = target.state.selected_source(layer)
+            if source is None or source.kind != "segmentation":
+                return CommandResult(
+                    False,
+                    "Per-label colours apply only to segmentation layers.",
+                )
         if visible is not None:
-            target.set_selected_visibility(visible)
+            target.set_selected_visibility(visible, layer)
         if opacity is not None:
-            target.set_selected_opacity(opacity)
+            target.set_selected_opacity(opacity, layer)
         if colour is not None:
-            target.set_selected_colour(tuple(int(value) for value in colour))
+            target.set_selected_colour(
+                tuple(int(value) for value in colour),
+                layer,
+            )
         if render_mode is not None:
-            target.set_selected_render_mode(str(render_mode))
+            target.set_selected_render_mode(str(render_mode), layer)
         if threshold is not None:
-            target.set_selected_threshold(float(threshold))
+            target.set_selected_threshold(float(threshold), layer)
         if mask_source_id is not _UNSET:
-            target.set_selected_mask_source(normalized_mask_id)
-        return CommandResult(True, "3D display settings updated.", target.status())
+            target.set_selected_mask_source(normalized_mask_id, layer)
+        if label_colour is not None:
+            target.set_selected_label_colour(
+                int(label_colour[0]),
+                tuple(int(value) for value in label_colour[1:]),
+                layer,
+            )
+        return CommandResult(
+            True,
+            f"3D {layer} display settings updated.",
+            target.state.layer_status(layer),
+        )
 
     def reset_render3d_camera(
         self,
         session_id: str | None = None,
+        layer: str = RENDER_LAYER_BASE,
     ) -> CommandResult:
+        invalid_layer = _validate_render3d_layer(layer)
+        if invalid_layer is not None:
+            return invalid_layer
         target = self._render3d_target(session_id)
         if isinstance(target, CommandResult):
             return target
         if not target.state.active:
             return CommandResult(False, "Activate the 3D view before resetting its camera.")
         target.reset_camera()
-        return CommandResult(True, "3D camera reset.", target.status())
+        return CommandResult(
+            True,
+            "3D camera reset.",
+            target.state.layer_status(layer),
+        )
 
     def get_vessel_graph_status(
         self,

--- a/src/mipview/ui/main_window.py
+++ b/src/mipview/ui/main_window.py
@@ -1958,6 +1958,7 @@ class MainWindow(QMainWindow):
                 display_name=segmentation.display_name,
                 volume=segmentation.volume,
                 kind="segmentation",
+                overlay_eligible=segmentation.path is not None,
             )
             for segmentation in self.state.loaded_segmentations
         )

--- a/src/mipview/ui/main_window.py
+++ b/src/mipview/ui/main_window.py
@@ -96,6 +96,7 @@ from mipview.vessel_graph import (
     full_vessel_graph_geometry,
     load_vessel_graphml,
 )
+from mipview.version import versioned_window_title
 
 ANNOTATION_LOAD_FILTER = (
     "Annotation Files (*.nii *.nii.gz *.json);;"
@@ -111,7 +112,7 @@ RECON_ANNOTATION_SEGMENTATION_NAME = f"recon_{ANNOTATION_SEGMENTATION_NAME}"
 class MainWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
-        self.setWindowTitle("MipView")
+        self.setWindowTitle(versioned_window_title("MipView"))
         self.resize(1100, 700)
         self.state = AppState()
         self._font_scaler = ResponsiveFontScaler(

--- a/src/mipview/ui/patch_window.py
+++ b/src/mipview/ui/patch_window.py
@@ -117,6 +117,7 @@ from mipview.vessel_graph import (
     VesselGraphRenderGeometry,
     clip_vessel_graph_to_patch,
 )
+from mipview.version import versioned_window_title
 
 
 class PatchViewerWindow(QMainWindow):
@@ -165,7 +166,7 @@ class PatchViewerWindow(QMainWindow):
         active_segmentation_kind: str | None = None,
     ) -> None:
         super().__init__(parent)
-        self.setWindowTitle("Selected Patch")
+        self.setWindowTitle(versioned_window_title("Selected Patch"))
         self.setAcceptDrops(False)
 
         self._source_image_name = source_image_name

--- a/src/mipview/ui/volume_3d_panel.py
+++ b/src/mipview/ui/volume_3d_panel.py
@@ -32,11 +32,20 @@ class Volume3DPanel(CollapsibleGroupBox):
     vessel_graph_edge_thickness_changed = Signal(int)
     vessel_graph_unload_requested = Signal(object)
     colour_changed = Signal(object)
+    label_colour_changed = Signal(int, object)
     render_mode_changed = Signal(str)
     mask_changed = Signal(object)
     threshold_changed = Signal(float)
     update_requested = Signal()
     reset_camera_requested = Signal()
+    overlay_source_changed = Signal(object)
+    overlay_opacity_changed = Signal(float)
+    overlay_label_colour_changed = Signal(int, object)
+    overlay_render_mode_changed = Signal(str)
+    overlay_mask_changed = Signal(object)
+    overlay_threshold_changed = Signal(float)
+    overlay_vessel_graph_node_size_changed = Signal(int)
+    overlay_vessel_graph_edge_thickness_changed = Signal(int)
 
     def __init__(
         self,
@@ -46,7 +55,10 @@ class Volume3DPanel(CollapsibleGroupBox):
     ) -> None:
         super().__init__("3D Volume", parent)
         self._colour = (255, 255, 255)
+        self._label_colours: dict[int, tuple[int, int, int]] = {}
         self._source_kind: str | None = None
+        self._overlay_label_colours: dict[int, tuple[int, int, int]] = {}
+        self._overlay_source_kind: str | None = None
 
         form = QFormLayout(self)
         form.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
@@ -70,6 +82,18 @@ class Volume3DPanel(CollapsibleGroupBox):
         self.colour_button = QPushButton("Choose…", self)
         self.colour_button.clicked.connect(self._choose_colour)
         self._refresh_colour_button()
+
+        self.label_colour_combo = QComboBox(self)
+        self.label_colour_combo.currentIndexChanged.connect(
+            lambda _index: self._refresh_label_colour_button()
+        )
+        self.label_colour_button = QPushButton("Choose…", self)
+        self.label_colour_button.clicked.connect(self._choose_label_colour)
+        self.label_colour_widget = QWidget(self)
+        label_colour_layout = QHBoxLayout(self.label_colour_widget)
+        label_colour_layout.setContentsMargins(0, 0, 0, 0)
+        label_colour_layout.addWidget(self.label_colour_combo)
+        label_colour_layout.addWidget(self.label_colour_button)
 
         self.render_mode_combo = QComboBox(self)
         self.render_mode_combo.currentTextChanged.connect(
@@ -158,20 +182,152 @@ class Volume3DPanel(CollapsibleGroupBox):
             self.vessel_graph_unload_button = None
         self.vessel_graph_group.setVisible(False)
 
+        self.overlay_group = QGroupBox("3D Overlay", self)
+        overlay_form = QFormLayout(self.overlay_group)
+        overlay_form.setRowWrapPolicy(QFormLayout.RowWrapPolicy.WrapLongRows)
+
+        self.overlay_source_combo = QComboBox(self.overlay_group)
+        self.overlay_source_combo.addItem("---", None)
+        self.overlay_source_combo.currentIndexChanged.connect(
+            lambda _index: self.overlay_source_changed.emit(
+                self.overlay_source_combo.currentData()
+            )
+        )
+
+        self.overlay_opacity_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.overlay_group,
+        )
+        self.overlay_opacity_slider.setRange(0, 100)
+        self.overlay_opacity_slider.setValue(100)
+        self.overlay_opacity_slider.valueChanged.connect(
+            lambda value: self.overlay_opacity_changed.emit(value / 100.0)
+        )
+
+        self.overlay_label_colour_combo = QComboBox(self.overlay_group)
+        self.overlay_label_colour_combo.currentIndexChanged.connect(
+            lambda _index: self._refresh_overlay_label_colour_button()
+        )
+        self.overlay_label_colour_button = QPushButton(
+            "Choose…",
+            self.overlay_group,
+        )
+        self.overlay_label_colour_button.clicked.connect(
+            self._choose_overlay_label_colour
+        )
+        self.overlay_label_colour_widget = QWidget(self.overlay_group)
+        overlay_label_colour_layout = QHBoxLayout(
+            self.overlay_label_colour_widget
+        )
+        overlay_label_colour_layout.setContentsMargins(0, 0, 0, 0)
+        overlay_label_colour_layout.addWidget(self.overlay_label_colour_combo)
+        overlay_label_colour_layout.addWidget(self.overlay_label_colour_button)
+
+        self.overlay_render_mode_combo = QComboBox(self.overlay_group)
+        self.overlay_render_mode_combo.currentTextChanged.connect(
+            self._on_overlay_render_mode_changed
+        )
+
+        self.overlay_mask_combo = QComboBox(self.overlay_group)
+        self.overlay_mask_combo.addItem("---", None)
+        self.overlay_mask_combo.currentIndexChanged.connect(
+            lambda _index: self.overlay_mask_changed.emit(
+                self.overlay_mask_combo.currentData()
+            )
+        )
+        self.overlay_mask_label = QLabel("Mask:", self.overlay_group)
+
+        self.overlay_threshold_spinbox = QDoubleSpinBox(self.overlay_group)
+        self.overlay_threshold_spinbox.setDecimals(4)
+        self.overlay_threshold_spinbox.setRange(-1.0e12, 1.0e12)
+        self.overlay_threshold_spinbox.valueChanged.connect(
+            self.overlay_threshold_changed.emit
+        )
+
+        self.overlay_vessel_graph_group = QGroupBox(
+            "Vessel Graph",
+            self.overlay_group,
+        )
+        overlay_vessel_form = QFormLayout(self.overlay_vessel_graph_group)
+        self.overlay_vessel_graph_opacity_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.overlay_vessel_graph_group,
+        )
+        self.overlay_vessel_graph_opacity_slider.setRange(0, 100)
+        self.overlay_vessel_graph_opacity_slider.setValue(100)
+        self.overlay_vessel_graph_opacity_slider.valueChanged.connect(
+            lambda value: self.overlay_opacity_changed.emit(value / 100.0)
+        )
+        self.overlay_vessel_graph_node_size_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.overlay_vessel_graph_group,
+        )
+        self.overlay_vessel_graph_node_size_slider.setRange(1, 10)
+        self.overlay_vessel_graph_node_size_slider.setValue(4)
+        self.overlay_vessel_graph_node_size_slider.valueChanged.connect(
+            self.overlay_vessel_graph_node_size_changed.emit
+        )
+        self.overlay_vessel_graph_edge_thickness_slider = QSlider(
+            Qt.Orientation.Horizontal,
+            self.overlay_vessel_graph_group,
+        )
+        self.overlay_vessel_graph_edge_thickness_slider.setRange(1, 10)
+        self.overlay_vessel_graph_edge_thickness_slider.setValue(2)
+        self.overlay_vessel_graph_edge_thickness_slider.valueChanged.connect(
+            self.overlay_vessel_graph_edge_thickness_changed.emit
+        )
+        overlay_vessel_form.addRow(
+            "Opacity:",
+            self.overlay_vessel_graph_opacity_slider,
+        )
+        overlay_vessel_form.addRow(
+            "Node size:",
+            self.overlay_vessel_graph_node_size_slider,
+        )
+        overlay_vessel_form.addRow(
+            "Edge thickness:",
+            self.overlay_vessel_graph_edge_thickness_slider,
+        )
+        self.overlay_vessel_graph_group.setVisible(False)
+
+        self.overlay_opacity_label = QLabel("Opacity:", self.overlay_group)
+        self.overlay_label_colour_label = QLabel(
+            "Label colour:",
+            self.overlay_group,
+        )
+        overlay_form.addRow("File:", self.overlay_source_combo)
+        overlay_form.addRow(
+            self.overlay_opacity_label,
+            self.overlay_opacity_slider,
+        )
+        overlay_form.addRow(
+            self.overlay_label_colour_label,
+            self.overlay_label_colour_widget,
+        )
+        overlay_form.addRow("Render mode:", self.overlay_render_mode_combo)
+        overlay_form.addRow(self.overlay_mask_label, self.overlay_mask_combo)
+        overlay_form.addRow("Threshold:", self.overlay_threshold_spinbox)
+        overlay_form.addRow(self.overlay_vessel_graph_group)
+
         self.opacity_label = QLabel("Opacity:", self)
+        self.label_colour_label = QLabel("Label colour:", self)
         form.addRow(self.activation_button)
         form.addRow("3D Layer:", self.source_combo)
         form.addRow(self.opacity_label, self.opacity_slider)
         form.addRow("Colour:", self.colour_button)
+        form.addRow(self.label_colour_label, self.label_colour_widget)
         form.addRow("Render mode:", self.render_mode_combo)
         form.addRow(self.mask_label, self.mask_combo)
         form.addRow("Threshold:", self.threshold_spinbox)
+        form.addRow(self.overlay_group)
         form.addRow(action_row)
         form.addRow(self.progress_bar)
         form.addRow(self.status_label)
         form.addRow(self.vessel_graph_group)
         self.set_render_controls_enabled(False)
         self._refresh_mask_availability()
+        self.set_overlay_source_kind(None)
+        self.set_overlay_controls_enabled(False)
 
     def set_sources(
         self,
@@ -197,6 +353,29 @@ class Volume3DPanel(CollapsibleGroupBox):
         source_id = self.source_combo.currentData()
         return source_id if isinstance(source_id, str) else None
 
+    def set_overlay_sources(
+        self,
+        sources: Sequence[tuple[str, str]],
+        selected_source_id: str | None,
+    ) -> None:
+        was_blocked = self.overlay_source_combo.blockSignals(True)
+        self.overlay_source_combo.clear()
+        self.overlay_source_combo.addItem("---", None)
+        selected_index = 0
+        for source_id, display_name in sources:
+            self.overlay_source_combo.addItem(display_name, source_id)
+            if source_id == selected_source_id:
+                selected_index = self.overlay_source_combo.count() - 1
+        self.overlay_source_combo.setCurrentIndex(selected_index)
+        self.overlay_source_combo.blockSignals(was_blocked)
+        self.set_overlay_controls_enabled(
+            selected_index > 0
+        )
+
+    def selected_overlay_source_id(self) -> str | None:
+        source_id = self.overlay_source_combo.currentData()
+        return source_id if isinstance(source_id, str) else None
+
     def set_modes(self, modes: Sequence[str], selected_mode: str) -> None:
         was_blocked = self.render_mode_combo.blockSignals(True)
         self.render_mode_combo.clear()
@@ -206,6 +385,20 @@ class Volume3DPanel(CollapsibleGroupBox):
         self.render_mode_combo.blockSignals(was_blocked)
         self._refresh_threshold_availability()
         self._refresh_mask_availability()
+
+    def set_overlay_modes(
+        self,
+        modes: Sequence[str],
+        selected_mode: str,
+    ) -> None:
+        was_blocked = self.overlay_render_mode_combo.blockSignals(True)
+        self.overlay_render_mode_combo.clear()
+        self.overlay_render_mode_combo.addItems(list(modes))
+        index = self.overlay_render_mode_combo.findText(selected_mode)
+        self.overlay_render_mode_combo.setCurrentIndex(max(index, 0))
+        self.overlay_render_mode_combo.blockSignals(was_blocked)
+        self._refresh_overlay_threshold_availability()
+        self._refresh_overlay_mask_availability()
 
     def set_masks(
         self,
@@ -223,6 +416,23 @@ class Volume3DPanel(CollapsibleGroupBox):
         self.mask_combo.setCurrentIndex(selected_index)
         self.mask_combo.blockSignals(was_blocked)
         self._refresh_mask_availability()
+
+    def set_overlay_masks(
+        self,
+        masks: Sequence[tuple[str, str]],
+        selected_mask_id: str | None,
+    ) -> None:
+        was_blocked = self.overlay_mask_combo.blockSignals(True)
+        self.overlay_mask_combo.clear()
+        self.overlay_mask_combo.addItem("---", None)
+        selected_index = 0
+        for source_id, display_name in masks:
+            self.overlay_mask_combo.addItem(display_name, source_id)
+            if source_id == selected_mask_id:
+                selected_index = self.overlay_mask_combo.count() - 1
+        self.overlay_mask_combo.setCurrentIndex(selected_index)
+        self.overlay_mask_combo.blockSignals(was_blocked)
+        self._refresh_overlay_mask_availability()
 
     def set_settings(self, settings: Render3DSettings) -> None:
         blockers: list[tuple[QWidget, bool]] = []
@@ -262,6 +472,85 @@ class Volume3DPanel(CollapsibleGroupBox):
             "Update required." if settings.dirty else "3D layer ready."
         )
 
+    def set_label_colours(
+        self,
+        labels: Sequence[int],
+        settings: Render3DSettings,
+    ) -> None:
+        self._label_colours = {
+            int(label): settings.colour_for_label(int(label))
+            for label in labels
+        }
+        selected_label = self.label_colour_combo.currentData()
+        was_blocked = self.label_colour_combo.blockSignals(True)
+        self.label_colour_combo.clear()
+        selected_index = 0
+        for label in labels:
+            self.label_colour_combo.addItem(f"Label {int(label)}", int(label))
+            if int(label) == selected_label:
+                selected_index = self.label_colour_combo.count() - 1
+        if self.label_colour_combo.count() > 0:
+            self.label_colour_combo.setCurrentIndex(selected_index)
+        self.label_colour_combo.blockSignals(was_blocked)
+        self._refresh_label_colour_button()
+
+    def set_overlay_settings(
+        self,
+        settings: Render3DSettings,
+        labels: Sequence[int] = (),
+    ) -> None:
+        blockers: list[tuple[QWidget, bool]] = []
+        for widget in (
+            self.overlay_opacity_slider,
+            self.overlay_vessel_graph_opacity_slider,
+            self.overlay_vessel_graph_node_size_slider,
+            self.overlay_vessel_graph_edge_thickness_slider,
+            self.overlay_mask_combo,
+            self.overlay_threshold_spinbox,
+        ):
+            blockers.append((widget, widget.blockSignals(True)))
+        opacity_value = int(round(settings.opacity * 100.0))
+        self.overlay_opacity_slider.setValue(opacity_value)
+        self.overlay_vessel_graph_opacity_slider.setValue(opacity_value)
+        self.overlay_vessel_graph_node_size_slider.setValue(settings.node_size)
+        self.overlay_vessel_graph_edge_thickness_slider.setValue(
+            settings.edge_thickness
+        )
+        self.overlay_threshold_spinbox.setValue(settings.threshold)
+        mask_index = self.overlay_mask_combo.findData(settings.mask_source_id)
+        self.overlay_mask_combo.setCurrentIndex(max(mask_index, 0))
+        for widget, blocked in blockers:
+            widget.blockSignals(blocked)
+
+        mode_index = self.overlay_render_mode_combo.findText(
+            settings.render_mode
+        )
+        if mode_index >= 0:
+            was_blocked = self.overlay_render_mode_combo.blockSignals(True)
+            self.overlay_render_mode_combo.setCurrentIndex(mode_index)
+            self.overlay_render_mode_combo.blockSignals(was_blocked)
+        self._overlay_label_colours = {
+            int(label): settings.colour_for_label(int(label))
+            for label in labels
+        }
+        selected_label = self.overlay_label_colour_combo.currentData()
+        was_blocked = self.overlay_label_colour_combo.blockSignals(True)
+        self.overlay_label_colour_combo.clear()
+        selected_index = 0
+        for label in labels:
+            self.overlay_label_colour_combo.addItem(
+                f"Label {int(label)}",
+                int(label),
+            )
+            if int(label) == selected_label:
+                selected_index = self.overlay_label_colour_combo.count() - 1
+        if self.overlay_label_colour_combo.count() > 0:
+            self.overlay_label_colour_combo.setCurrentIndex(selected_index)
+        self.overlay_label_colour_combo.blockSignals(was_blocked)
+        self._refresh_overlay_label_colour_button()
+        self._refresh_overlay_threshold_availability()
+        self._refresh_overlay_mask_availability()
+
     def set_active(self, active: bool) -> None:
         was_blocked = self.activation_button.blockSignals(True)
         self.activation_button.setChecked(active)
@@ -281,6 +570,12 @@ class Volume3DPanel(CollapsibleGroupBox):
             self.reset_camera_button,
         ):
             widget.setEnabled(enabled)
+        self.label_colour_combo.setEnabled(
+            enabled and self.label_colour_combo.count() > 0
+        )
+        self.label_colour_button.setEnabled(
+            enabled and isinstance(self.label_colour_combo.currentData(), int)
+        )
         is_graph = self._source_kind == "vessel_graph"
         self.colour_button.setEnabled(enabled and not is_graph)
         self.render_mode_combo.setEnabled(enabled and not is_graph)
@@ -296,17 +591,74 @@ class Volume3DPanel(CollapsibleGroupBox):
         self._refresh_threshold_availability()
         self._refresh_mask_availability()
 
+    def set_overlay_controls_enabled(self, enabled: bool) -> None:
+        self.overlay_source_combo.setEnabled(True)
+        is_graph = self._overlay_source_kind == "vessel_graph"
+        for widget in (
+            self.overlay_opacity_slider,
+            self.overlay_render_mode_combo,
+            self.overlay_mask_combo,
+            self.overlay_threshold_spinbox,
+        ):
+            widget.setEnabled(enabled and not is_graph)
+        self.overlay_label_colour_combo.setEnabled(
+            enabled
+            and not is_graph
+            and self.overlay_label_colour_combo.count() > 0
+        )
+        self.overlay_label_colour_button.setEnabled(
+            enabled
+            and not is_graph
+            and isinstance(
+                self.overlay_label_colour_combo.currentData(),
+                int,
+            )
+        )
+        self.overlay_vessel_graph_opacity_slider.setEnabled(enabled and is_graph)
+        self.overlay_vessel_graph_node_size_slider.setEnabled(enabled and is_graph)
+        self.overlay_vessel_graph_edge_thickness_slider.setEnabled(
+            enabled and is_graph
+        )
+        self._refresh_overlay_threshold_availability()
+        self._refresh_overlay_mask_availability()
+
     def set_source_kind(self, source_kind: str | None) -> None:
         self._source_kind = source_kind
         is_graph = source_kind == "vessel_graph"
         self.vessel_graph_group.setVisible(is_graph)
         self.opacity_label.setVisible(not is_graph)
         self.opacity_slider.setVisible(not is_graph)
+        is_segmentation = source_kind == "segmentation"
+        self.colour_button.setVisible(source_kind == "image")
+        self.label_colour_label.setVisible(is_segmentation)
+        self.label_colour_widget.setVisible(is_segmentation)
+        if is_segmentation:
+            self.label_colour_button.setEnabled(
+                self.activation_button.isChecked()
+                and self.label_colour_combo.currentIndex() >= 0
+            )
         self._refresh_threshold_availability()
         self._refresh_mask_availability()
         self.set_render_controls_enabled(
             self.activation_button.isChecked()
             and self.source_combo.currentIndex() >= 0
+        )
+
+    def set_overlay_source_kind(self, source_kind: str | None) -> None:
+        self._overlay_source_kind = source_kind
+        is_graph = source_kind == "vessel_graph"
+        is_segmentation = source_kind == "segmentation"
+        self.overlay_vessel_graph_group.setVisible(is_graph)
+        self.overlay_opacity_label.setVisible(not is_graph)
+        self.overlay_opacity_slider.setVisible(not is_graph)
+        self.overlay_label_colour_label.setVisible(is_segmentation)
+        self.overlay_label_colour_widget.setVisible(is_segmentation)
+        self.overlay_render_mode_combo.setVisible(source_kind is not None)
+        self.overlay_threshold_spinbox.setVisible(is_segmentation)
+        self._refresh_overlay_threshold_availability()
+        self._refresh_overlay_mask_availability()
+        self.set_overlay_controls_enabled(
+            self.overlay_source_combo.currentIndex() > 0
         )
 
     def set_busy(self, busy: bool, message: str = "Preparing 3D layer…") -> None:
@@ -349,6 +701,11 @@ class Volume3DPanel(CollapsibleGroupBox):
         self._refresh_mask_availability()
         self.render_mode_changed.emit(render_mode)
 
+    def _on_overlay_render_mode_changed(self, render_mode: str) -> None:
+        self._refresh_overlay_threshold_availability()
+        self._refresh_overlay_mask_availability()
+        self.overlay_render_mode_changed.emit(render_mode)
+
     def _choose_colour(self) -> None:
         selected = QColorDialog.getColor(QColor(*self._colour), self, "3D Layer Colour")
         if not selected.isValid():
@@ -357,12 +714,83 @@ class Volume3DPanel(CollapsibleGroupBox):
         self._refresh_colour_button()
         self.colour_changed.emit(self._colour)
 
+    def _choose_label_colour(self) -> None:
+        label = self.label_colour_combo.currentData()
+        if not isinstance(label, int):
+            return
+        current = self._label_colours.get(label, (255, 255, 255))
+        selected = QColorDialog.getColor(
+            QColor(*current),
+            self,
+            f"3D Label {label} Colour",
+        )
+        if not selected.isValid():
+            return
+        colour = (selected.red(), selected.green(), selected.blue())
+        self._label_colours[label] = colour
+        self._refresh_label_colour_button()
+        self.label_colour_changed.emit(label, colour)
+
+    def _choose_overlay_label_colour(self) -> None:
+        label = self.overlay_label_colour_combo.currentData()
+        if not isinstance(label, int):
+            return
+        current = self._overlay_label_colours.get(label, (255, 255, 255))
+        selected = QColorDialog.getColor(
+            QColor(*current),
+            self,
+            f"3D Overlay Label {label} Colour",
+        )
+        if not selected.isValid():
+            return
+        colour = (selected.red(), selected.green(), selected.blue())
+        self._overlay_label_colours[label] = colour
+        self._refresh_overlay_label_colour_button()
+        self.overlay_label_colour_changed.emit(label, colour)
+
     def _refresh_colour_button(self) -> None:
         red, green, blue = self._colour
         foreground = "#000" if red + green + blue > 420 else "#fff"
         self.colour_button.setStyleSheet(
             f"background-color: rgb({red}, {green}, {blue}); color: {foreground};"
         )
+
+    def _refresh_label_colour_button(self) -> None:
+        label = self.label_colour_combo.currentData()
+        colour = (
+            self._label_colours.get(label)
+            if isinstance(label, int)
+            else None
+        )
+        self._set_colour_button_style(self.label_colour_button, colour)
+
+    def _refresh_overlay_label_colour_button(self) -> None:
+        label = self.overlay_label_colour_combo.currentData()
+        colour = (
+            self._overlay_label_colours.get(label)
+            if isinstance(label, int)
+            else None
+        )
+        self._set_colour_button_style(
+            self.overlay_label_colour_button,
+            colour,
+        )
+
+    @staticmethod
+    def _set_colour_button_style(
+        button: QPushButton,
+        colour: tuple[int, int, int] | None,
+    ) -> None:
+        if colour is None:
+            button.setStyleSheet("")
+            button.setEnabled(False)
+            return
+        red, green, blue = colour
+        foreground = "#000" if red + green + blue > 420 else "#fff"
+        button.setStyleSheet(
+            f"background-color: rgb({red}, {green}, {blue}); color: {foreground};"
+        )
+        button.setEnabled(True)
 
     def _refresh_threshold_availability(self) -> None:
         mode = self.render_mode_combo.currentText()
@@ -385,4 +813,25 @@ class Volume3DPanel(CollapsibleGroupBox):
             visible
             and self.activation_button.isChecked()
             and self.source_combo.currentIndex() >= 0
+        )
+
+    def _refresh_overlay_threshold_availability(self) -> None:
+        mode = self.overlay_render_mode_combo.currentText()
+        available = (
+            self._overlay_source_kind == "segmentation"
+            and mode in {"Surface", "Points"}
+        )
+        self.overlay_threshold_spinbox.setEnabled(available)
+
+    def _refresh_overlay_mask_availability(self) -> None:
+        mode = self.overlay_render_mode_combo.currentText()
+        visible = (
+            self._overlay_source_kind == "segmentation"
+            and mode in {"Surface", "Points"}
+        )
+        self.overlay_mask_label.setVisible(visible)
+        self.overlay_mask_combo.setVisible(visible)
+        self.overlay_mask_combo.setEnabled(
+            visible
+            and self.overlay_source_combo.currentIndex() > 0
         )

--- a/src/mipview/version.py
+++ b/src/mipview/version.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from functools import cache
+from importlib.metadata import PackageNotFoundError, version as package_version
+from pathlib import Path
+import tomllib
+
+
+@cache
+def current_version() -> str:
+    """Return the source-tree or installed MipView package version."""
+    pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    if pyproject_path.is_file():
+        try:
+            with pyproject_path.open("rb") as pyproject_file:
+                project = tomllib.load(pyproject_file).get("project", {})
+            version = project.get("version")
+            if isinstance(version, str) and version.strip():
+                return version.strip()
+        except (OSError, tomllib.TOMLDecodeError):
+            pass
+
+    try:
+        return package_version("mipview")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def versioned_window_title(title: str) -> str:
+    """Append the current MipView version to a window title."""
+    return f"{title} (Version: {current_version()})"

--- a/src/mipview/viewer/render_3d_preparation.py
+++ b/src/mipview/viewer/render_3d_preparation.py
@@ -10,6 +10,7 @@ from skimage.measure import marching_cubes
 from mipview.io.nifti_io import NiftiLoadResult
 from mipview.patch.selector import PatchBounds
 from mipview.vessel_graph.model import VesselGraphRenderGeometry
+from mipview.viewer.render_3d_state import segmentation_labels
 
 
 MAX_VOLUME_DIMENSION = 256
@@ -30,6 +31,7 @@ class PreparedRender3D:
     stride: tuple[int, int, int]
     source_range: tuple[float, float]
     mask_applied: bool = False
+    vertex_labels: np.ndarray | None = None
     graph_edge_segments: np.ndarray | None = None
     graph_node_positions: np.ndarray | None = None
     graph_intercept_positions: np.ndarray | None = None
@@ -159,14 +161,37 @@ def prepare_render(
             mask_applied=sampled_mask is not None,
         )
 
+    labels = segmentation_labels(volume)
     foreground = np.asarray(np.isfinite(sampled) & (sampled > float(threshold)))
     if sampled_mask is not None:
         foreground &= sampled_mask
+    included_labels = tuple(
+        label for label in labels if float(label) > float(threshold)
+    )
     if render_mode == "Points":
-        points = np.argwhere(foreground)
+        points_parts: list[np.ndarray] = []
+        point_label_parts: list[np.ndarray] = []
+        for label in included_labels:
+            label_points = np.argwhere(foreground & (sampled == label))
+            if label_points.size:
+                points_parts.append(label_points)
+                point_label_parts.append(
+                    np.full(label_points.shape[0], label, dtype=np.int64)
+                )
+        points = (
+            np.concatenate(points_parts, axis=0)
+            if points_parts
+            else np.empty((0, 3), dtype=np.int64)
+        )
+        point_labels = (
+            np.concatenate(point_label_parts, axis=0)
+            if point_label_parts
+            else np.empty((0,), dtype=np.int64)
+        )
         if points.shape[0] > MAX_POINT_COUNT:
             selection_stride = math.ceil(points.shape[0] / MAX_POINT_COUNT)
             points = points[::selection_stride]
+            point_labels = point_labels[::selection_stride]
         source_points = points.astype(np.float32) * float(stride_value)
         vertices = np.asarray(
             apply_affine(volume.affine, source_points),
@@ -183,14 +208,23 @@ def prepare_render(
             stride=stride,
             source_range=source_range,
             mask_applied=sampled_mask is not None,
+            vertex_labels=point_labels,
         )
 
-    if not np.any(foreground):
-        vertices = np.empty((0, 3), dtype=np.float32)
-        faces = np.empty((0, 3), dtype=np.uint32)
-    else:
-        padded = np.pad(foreground.astype(np.uint8), 1)
-        surface_step = _surface_step_size(foreground)
+    vertex_parts: list[np.ndarray] = []
+    face_parts: list[np.ndarray] = []
+    vertex_label_parts: list[np.ndarray] = []
+    vertex_offset = 0
+    face_budget = max(
+        1,
+        MAX_SURFACE_FACES // max(len(included_labels), 1),
+    )
+    for label in included_labels:
+        label_foreground = foreground & (sampled == label)
+        if not np.any(label_foreground):
+            continue
+        padded = np.pad(label_foreground.astype(np.uint8), 1)
+        surface_step = _surface_step_size(label_foreground)
         while True:
             raw_vertices, raw_faces, _normals, _values = marching_cubes(
                 padded,
@@ -199,18 +233,34 @@ def prepare_render(
                 allow_degenerate=False,
             )
             if (
-                raw_faces.shape[0] <= MAX_SURFACE_FACES
-                or surface_step >= min(foreground.shape)
+                raw_faces.shape[0] <= face_budget
+                or surface_step >= min(label_foreground.shape)
             ):
                 break
             surface_step *= 2
-        # Remove the padding, restore source voxel scale, then use world space.
         source_vertices = (raw_vertices - 1.0) * float(stride_value)
-        vertices = np.asarray(
+        label_vertices = np.asarray(
             apply_affine(volume.affine, source_vertices),
             dtype=np.float32,
         )
-        faces = np.asarray(raw_faces, dtype=np.uint32)
+        label_faces = np.asarray(raw_faces, dtype=np.uint32) + np.uint32(
+            vertex_offset
+        )
+        vertex_parts.append(label_vertices)
+        face_parts.append(label_faces)
+        vertex_label_parts.append(
+            np.full(label_vertices.shape[0], label, dtype=np.int64)
+        )
+        vertex_offset += label_vertices.shape[0]
+
+    if not vertex_parts:
+        vertices = np.empty((0, 3), dtype=np.float32)
+        faces = np.empty((0, 3), dtype=np.uint32)
+        vertex_labels = np.empty((0,), dtype=np.int64)
+    else:
+        vertices = np.concatenate(vertex_parts, axis=0)
+        faces = np.concatenate(face_parts, axis=0)
+        vertex_labels = np.concatenate(vertex_label_parts, axis=0)
     return PreparedRender3D(
         kind=kind,
         render_mode=render_mode,
@@ -222,6 +272,7 @@ def prepare_render(
         stride=stride,
         source_range=source_range,
         mask_applied=sampled_mask is not None,
+        vertex_labels=vertex_labels,
     )
 
 

--- a/src/mipview/viewer/render_3d_state.py
+++ b/src/mipview/viewer/render_3d_state.py
@@ -5,14 +5,19 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from mipview.io.nifti_io import NiftiLoadResult
+from mipview.segmentation.overlay import segmentation_label_color
 from mipview.vessel_graph.model import VesselGraphRenderGeometry
 
 
+RENDER_LAYER_BASE = "base"
+RENDER_LAYER_OVERLAY = "overlay"
+RENDER_LAYERS = (RENDER_LAYER_BASE, RENDER_LAYER_OVERLAY)
 RAW_RENDER_MODES = ("MIP", "MinIP", "Translucent", "Isosurface")
 SEGMENTATION_RENDER_MODES = ("Surface", "Points")
 VESSEL_GRAPH_RENDER_MODES = ("Skeleton",)
 MASKED_IMAGE_RENDER_MODES = ("MIP", "MinIP")
 MASKED_SEGMENTATION_RENDER_MODES = SEGMENTATION_RENDER_MODES
+MAX_SEGMENTATION_LABELS = 256
 
 
 @dataclass(frozen=True)
@@ -24,6 +29,7 @@ class Render3DSource:
     volume: NiftiLoadResult | None
     kind: str
     vessel_graph: VesselGraphRenderGeometry | None = None
+    overlay_eligible: bool = True
 
     def __post_init__(self) -> None:
         if self.kind not in {"image", "segmentation", "vessel_graph"}:
@@ -51,6 +57,7 @@ class Render3DSettings:
     threshold: float = 0.0
     node_size: int = 4
     edge_thickness: int = 2
+    label_colours: dict[int, tuple[int, int, int]] = field(default_factory=dict)
     dirty: bool = True
 
     def set_opacity(self, opacity: float) -> None:
@@ -67,6 +74,26 @@ class Render3DSettings:
     def set_edge_thickness(self, edge_thickness: int) -> None:
         self.edge_thickness = min(max(int(edge_thickness), 1), 10)
 
+    def set_label_colour(
+        self,
+        label: int,
+        colour: tuple[int, int, int],
+    ) -> None:
+        label_value = int(label)
+        if label_value <= 0:
+            raise ValueError("3D segmentation colours require a positive label.")
+        if len(colour) != 3 or any(not 0 <= int(value) <= 255 for value in colour):
+            raise ValueError("3D label colour must contain three values in 0..255.")
+        self.label_colours[label_value] = tuple(int(value) for value in colour)
+
+    def colour_for_label(self, label: int) -> tuple[int, int, int]:
+        label_value = int(label)
+        configured = self.label_colours.get(label_value)
+        if configured is not None:
+            return configured
+        default = segmentation_label_color(label_value)
+        return tuple(int(value) for value in default)
+
 
 @dataclass
 class Render3DState:
@@ -74,51 +101,116 @@ class Render3DState:
 
     sources: dict[str, Render3DSource] = field(default_factory=dict)
     settings: dict[str, Render3DSettings] = field(default_factory=dict)
+    overlay_settings: dict[str, Render3DSettings] = field(default_factory=dict)
     selected_source_id: str | None = None
     rendered_source_id: str | None = None
+    overlay_selected_source_id: str | None = None
+    overlay_rendered_source_id: str | None = None
     active: bool = False
+    overlay_active: bool = False
     busy: bool = False
+    overlay_busy: bool = False
     last_error: str | None = None
+    overlay_last_error: str | None = None
     prepared_shape: tuple[int, int, int] | None = None
     downsample_stride: tuple[int, int, int] | None = None
+    overlay_prepared_shape: tuple[int, int, int] | None = None
+    overlay_downsample_stride: tuple[int, int, int] | None = None
 
     def set_sources(self, sources: list[Render3DSource]) -> None:
         new_sources = {source.id: source for source in sources}
         removed = set(self.sources).difference(new_sources)
         for source_id in removed:
             self.settings.pop(source_id, None)
+            self.overlay_settings.pop(source_id, None)
         self.sources = new_sources
 
         for source in sources:
             self.settings.setdefault(source.id, default_settings_for_source(source))
-        for source_id, settings in self.settings.items():
-            if settings.mask_source_id not in {
-                source.id for source in self.compatible_masks_for(source_id)
-            }:
-                settings.mask_source_id = None
+            self.overlay_settings.setdefault(
+                source.id,
+                default_settings_for_source(source),
+            )
+        for settings_by_layer in (self.settings, self.overlay_settings):
+            for source_id, settings in settings_by_layer.items():
+                if settings.mask_source_id not in {
+                    source.id for source in self.compatible_masks_for(source_id)
+                }:
+                    settings.mask_source_id = None
 
         if self.selected_source_id not in self.sources:
             self.selected_source_id = sources[0].id if sources else None
         if self.rendered_source_id not in self.sources:
             self.rendered_source_id = None
+        eligible_overlay_ids = {source.id for source in self.overlay_sources()}
+        if self.overlay_selected_source_id not in eligible_overlay_ids:
+            self.overlay_selected_source_id = None
+        if self.overlay_rendered_source_id not in eligible_overlay_ids:
+            self.overlay_rendered_source_id = None
 
-    def selected_source(self) -> Render3DSource | None:
-        if self.selected_source_id is None:
+    def overlay_sources(self) -> tuple[Render3DSource, ...]:
+        base = self.selected_source()
+        return tuple(
+            source
+            for source in self.sources.values()
+            if source.overlay_eligible
+            and source.kind in {"segmentation", "vessel_graph"}
+            and source.id != self.selected_source_id
+            and (
+                source.kind == "vessel_graph"
+                or base is None
+                or base.volume is None
+                or (
+                    source.volume is not None
+                    and _volumes_are_spatially_compatible(
+                        base.volume,
+                        source.volume,
+                    )
+                )
+            )
+        )
+
+    def selected_source(
+        self,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> Render3DSource | None:
+        source_id = self._selected_source_id(layer)
+        if source_id is None:
             return None
-        return self.sources.get(self.selected_source_id)
+        return self.sources.get(source_id)
 
-    def selected_settings(self) -> Render3DSettings | None:
-        if self.selected_source_id is None:
+    def selected_settings(
+        self,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> Render3DSettings | None:
+        source_id = self._selected_source_id(layer)
+        if source_id is None:
             return None
-        return self.settings.get(self.selected_source_id)
+        return self._settings_for_layer(layer).get(source_id)
 
-    def select_source(self, source_id: str | None) -> None:
+    def select_source(
+        self,
+        source_id: str | None,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        _validate_render_layer(layer)
         if source_id is not None and source_id not in self.sources:
             raise ValueError(f"3D render source does not exist: {source_id}")
+        if layer == RENDER_LAYER_OVERLAY:
+            eligible_ids = {source.id for source in self.overlay_sources()}
+            if source_id is not None and source_id not in eligible_ids:
+                raise ValueError(
+                    f"3D overlay source is unavailable or is selected as the base: {source_id}"
+                )
+            self.overlay_selected_source_id = source_id
+            return
         self.selected_source_id = source_id
+        if source_id == self.overlay_selected_source_id:
+            self.overlay_selected_source_id = None
+            self.overlay_rendered_source_id = None
 
-    def mark_selected_dirty(self) -> None:
-        settings = self.selected_settings()
+    def mark_selected_dirty(self, layer: str = RENDER_LAYER_BASE) -> None:
+        settings = self.selected_settings(layer)
         if settings is not None:
             settings.dirty = True
 
@@ -133,6 +225,7 @@ class Render3DState:
             candidate
             for candidate in self.sources.values()
             if candidate.kind == "segmentation"
+            and candidate.id != source.id
             and source.volume is not None
             and candidate.volume is not None
             and _volumes_are_spatially_compatible(
@@ -141,45 +234,81 @@ class Render3DState:
             )
         )
 
-    def selected_mask_source(self) -> Render3DSource | None:
-        settings = self.selected_settings()
+    def selected_mask_source(
+        self,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> Render3DSource | None:
+        settings = self.selected_settings(layer)
         if settings is None or settings.mask_source_id is None:
             return None
         compatible_ids = {
             source.id
-            for source in self.compatible_masks_for(self.selected_source_id)
+            for source in self.compatible_masks_for(self._selected_source_id(layer))
         }
         if settings.mask_source_id not in compatible_ids:
             return None
         return self.sources.get(settings.mask_source_id)
 
-    def status(self) -> dict[str, object]:
-        source = self.selected_source()
-        settings = self.selected_settings()
+    def layer_status(self, layer: str) -> dict[str, object]:
+        _validate_render_layer(layer)
+        source = self.selected_source(layer)
+        settings = self.selected_settings(layer)
+        selected_source_id = self._selected_source_id(layer)
+        rendered_source_id = (
+            self.rendered_source_id
+            if layer == RENDER_LAYER_BASE
+            else self.overlay_rendered_source_id
+        )
+        active = self.active if layer == RENDER_LAYER_BASE else self.overlay_active
+        busy = self.busy if layer == RENDER_LAYER_BASE else self.overlay_busy
+        prepared_shape = (
+            self.prepared_shape
+            if layer == RENDER_LAYER_BASE
+            else self.overlay_prepared_shape
+        )
+        downsample_stride = (
+            self.downsample_stride
+            if layer == RENDER_LAYER_BASE
+            else self.overlay_downsample_stride
+        )
+        last_error = (
+            self.last_error
+            if layer == RENDER_LAYER_BASE
+            else self.overlay_last_error
+        )
         return {
-            "active": self.active,
-            "busy": self.busy,
-            "selected_source_id": self.selected_source_id,
+            "layer": layer,
+            "active": active,
+            "busy": busy,
+            "selected_source_id": selected_source_id,
             "selected_source_name": None if source is None else source.display_name,
             "selected_source_kind": None if source is None else source.kind,
-            "rendered_source_id": self.rendered_source_id,
+            "rendered_source_id": rendered_source_id,
             "visible": None if settings is None else settings.visible,
             "opacity": None if settings is None else settings.opacity,
             "colour": None if settings is None else list(settings.colour),
+            "label_colours": (
+                None
+                if settings is None
+                else {
+                    str(label): list(colour)
+                    for label, colour in sorted(settings.label_colours.items())
+                }
+            ),
             "render_mode": None if settings is None else settings.render_mode,
             "mask_source_id": (
                 None if settings is None else settings.mask_source_id
             ),
             "mask_source_name": (
                 None
-                if settings is None or self.selected_mask_source() is None
-                else self.selected_mask_source().display_name
+                if settings is None or self.selected_mask_source(layer) is None
+                else self.selected_mask_source(layer).display_name
             ),
             "mask_applied": (
                 False
                 if source is None or settings is None
                 else render_mode_supports_mask(source.kind, settings.render_mode)
-                and self.selected_mask_source() is not None
+                and self.selected_mask_source(layer) is not None
             ),
             "threshold": None if settings is None else settings.threshold,
             "node_size": None if settings is None else settings.node_size,
@@ -188,15 +317,39 @@ class Render3DState:
             ),
             "update_required": None if settings is None else settings.dirty,
             "prepared_shape": (
-                None if self.prepared_shape is None else list(self.prepared_shape)
+                None if prepared_shape is None else list(prepared_shape)
             ),
             "downsample_stride": (
                 None
-                if self.downsample_stride is None
-                else list(self.downsample_stride)
+                if downsample_stride is None
+                else list(downsample_stride)
             ),
-            "last_error": self.last_error,
+            "last_error": last_error,
         }
+
+    def status(self) -> dict[str, object]:
+        base = self.layer_status(RENDER_LAYER_BASE)
+        overlay = self.layer_status(RENDER_LAYER_OVERLAY)
+        return {
+            **base,
+            "base": base,
+            "overlay": overlay,
+        }
+
+    def _selected_source_id(self, layer: str) -> str | None:
+        _validate_render_layer(layer)
+        return (
+            self.selected_source_id
+            if layer == RENDER_LAYER_BASE
+            else self.overlay_selected_source_id
+        )
+
+    def _settings_for_layer(
+        self,
+        layer: str,
+    ) -> dict[str, Render3DSettings]:
+        _validate_render_layer(layer)
+        return self.settings if layer == RENDER_LAYER_BASE else self.overlay_settings
 
 
 def default_settings_for_source(source: Render3DSource) -> Render3DSettings:
@@ -229,6 +382,33 @@ def render_mode_supports_mask(source_kind: str, render_mode: str) -> bool:
     if source_kind == "segmentation":
         return render_mode in MASKED_SEGMENTATION_RENDER_MODES
     return False
+
+
+def segmentation_labels(volume: NiftiLoadResult) -> tuple[int, ...]:
+    data = np.asarray(volume.data)
+    if data.ndim != 3:
+        raise ValueError(f"3D segmentation rendering expects 3D data, got {data.ndim}D.")
+    if not np.all(np.isfinite(data)):
+        raise ValueError("3D segmentation labels must all be finite.")
+    if np.any(data < 0):
+        raise ValueError("3D segmentation labels must be non-negative.")
+    rounded = np.rint(data)
+    if not np.array_equal(data, rounded):
+        raise ValueError("3D segmentation labels must be integer-valued.")
+    labels = tuple(int(value) for value in np.unique(rounded) if value > 0)
+    if len(labels) > MAX_SEGMENTATION_LABELS:
+        raise ValueError(
+            "3D segmentation rendering supports at most "
+            f"{MAX_SEGMENTATION_LABELS} foreground labels; found {len(labels)}."
+        )
+    return labels
+
+
+def _validate_render_layer(layer: str) -> None:
+    if layer not in RENDER_LAYERS:
+        raise ValueError(
+            f"3D render layer must be one of: {', '.join(RENDER_LAYERS)}."
+        )
 
 
 def _volumes_are_spatially_compatible(

--- a/src/mipview/viewer/volume_3d_widget.py
+++ b/src/mipview/viewer/volume_3d_widget.py
@@ -48,12 +48,15 @@ from mipview.viewer.render_3d_preparation import (
     source_box_world_segments,
 )
 from mipview.viewer.render_3d_state import (
+    RENDER_LAYER_BASE,
+    RENDER_LAYER_OVERLAY,
     RAW_RENDER_MODES,
     SEGMENTATION_RENDER_MODES,
     VESSEL_GRAPH_RENDER_MODES,
     Render3DSource,
     Render3DState,
     render_mode_supports_mask,
+    segmentation_labels,
 )
 from mipview.vessel_graph.model import (
     PROJECTED_INTERCEPT_COLOR,
@@ -347,11 +350,17 @@ class Volume3DWidget(QWidget):
         self._thread_pool = QThreadPool.globalInstance()
         self._job_token = 0
         self._workers: dict[int, _PreparationWorker] = {}
+        self._preparing_layer: str | None = None
+        self._pending_update_layers: list[str] = []
         self._canvas: Any | None = None
         self._view: Any | None = None
         self._active_visual: Any | None = None
         self._active_graph_visuals: dict[str, Any] = {}
         self._prepared: PreparedRender3D | None = None
+        self._overlay_visual: Any | None = None
+        self._overlay_depth_reset_visual: Any | None = None
+        self._overlay_graph_visuals: dict[str, Any] = {}
+        self._overlay_prepared: PreparedRender3D | None = None
         self._patch_visual: Any | None = None
         self._patch_extension_visual: Any | None = None
         self._source_box_visual: Any | None = None
@@ -410,103 +419,173 @@ class Volume3DWidget(QWidget):
             self.set_selected_edge_thickness
         )
         panel.colour_changed.connect(self.set_selected_colour)
+        panel.label_colour_changed.connect(self.set_selected_label_colour)
         panel.render_mode_changed.connect(self.set_selected_render_mode)
         panel.mask_changed.connect(self.set_selected_mask_source)
         panel.threshold_changed.connect(self.set_selected_threshold)
-        panel.update_requested.connect(self.update_selected_render)
+        panel.overlay_source_changed.connect(
+            lambda source_id: self.select_source(
+                source_id,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.overlay_opacity_changed.connect(
+            lambda opacity: self.set_selected_opacity(
+                opacity,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.overlay_label_colour_changed.connect(
+            lambda label, colour: self.set_selected_label_colour(
+                label,
+                colour,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.overlay_render_mode_changed.connect(
+            lambda mode: self.set_selected_render_mode(
+                mode,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.overlay_mask_changed.connect(
+            lambda source_id: self.set_selected_mask_source(
+                source_id,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.overlay_threshold_changed.connect(
+            lambda threshold: self.set_selected_threshold(
+                threshold,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.overlay_vessel_graph_node_size_changed.connect(
+            lambda size: self.set_selected_node_size(
+                size,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.overlay_vessel_graph_edge_thickness_changed.connect(
+            lambda thickness: self.set_selected_edge_thickness(
+                thickness,
+                RENDER_LAYER_OVERLAY,
+            )
+        )
+        panel.update_requested.connect(self.update_dirty_renders)
         panel.reset_camera_requested.connect(self.reset_camera)
         self._sync_panel_sources()
         self._sync_panel_settings()
 
     def set_sources(self, sources: list[Render3DSource]) -> None:
-        if self.state.busy:
+        if self.state.busy or self.state.overlay_busy:
             self._cancel_pending_preparation("Loaded files changed; update again.")
-        rendered_before = self.state.rendered_source_id
-        previous_source = (
-            None
-            if rendered_before is None
-            else self.state.sources.get(rendered_before)
-        )
-        previous_settings = (
-            None
-            if rendered_before is None
-            else self.state.settings.get(rendered_before)
-        )
-        previous_mask_id = (
-            None
-            if previous_settings is None
-            else previous_settings.mask_source_id
-        )
-        previous_mask_source = (
-            None
-            if previous_mask_id is None
-            else self.state.sources.get(previous_mask_id)
-        )
-        replacement_source = next(
-            (source for source in sources if source.id == rendered_before),
-            None,
-        )
-        replacement_mask_source = next(
-            (source for source in sources if source.id == previous_mask_id),
-            None,
-        )
+        previous_sources = dict(self.state.sources)
+        rendered_context: dict[str, tuple[str | None, str | None]] = {}
+        for layer in (RENDER_LAYER_BASE, RENDER_LAYER_OVERLAY):
+            rendered_id = self._rendered_source_id(layer)
+            settings_by_layer = (
+                self.state.settings
+                if layer == RENDER_LAYER_BASE
+                else self.state.overlay_settings
+            )
+            rendered_settings = (
+                None
+                if rendered_id is None
+                else settings_by_layer.get(rendered_id)
+            )
+            rendered_context[layer] = (
+                rendered_id,
+                (
+                    None
+                    if rendered_settings is None
+                    else rendered_settings.mask_source_id
+                ),
+            )
         self.state.set_sources(sources)
-        source_data_changed = (
-            previous_source is not None
-            and replacement_source is not None
-            and (
-                previous_source.volume is not replacement_source.volume
-                or previous_source.vessel_graph
-                is not replacement_source.vessel_graph
+        current_sources = self.state.sources
+        for layer, (rendered_id, mask_id) in rendered_context.items():
+            if rendered_id is None:
+                continue
+            previous = previous_sources.get(rendered_id)
+            replacement = current_sources.get(rendered_id)
+            previous_mask = (
+                None if mask_id is None else previous_sources.get(mask_id)
             )
-        )
-        mask_data_changed = (
-            previous_mask_source is not None
-            and previous_source is not None
-            and previous_settings is not None
-            and render_mode_supports_mask(
-                previous_source.kind,
-                previous_settings.render_mode,
+            replacement_mask = (
+                None if mask_id is None else current_sources.get(mask_id)
             )
-            and (
-                replacement_mask_source is None
-                or previous_mask_source.volume
-                is not replacement_mask_source.volume
+            changed = (
+                replacement is None
+                or previous is None
+                or previous.volume is not replacement.volume
+                or previous.vessel_graph is not replacement.vessel_graph
+                or (
+                    previous_mask is not None
+                    and (
+                        replacement_mask is None
+                        or previous_mask.volume is not replacement_mask.volume
+                    )
+                )
             )
-        )
-        if (
-            rendered_before is not None
-            and (
-                self.state.rendered_source_id is None
-                or source_data_changed
-                or mask_data_changed
+            current_rendered_id = (
+                self.state.rendered_source_id
+                if layer == RENDER_LAYER_BASE
+                else self.state.overlay_rendered_source_id
             )
-        ):
-            self._release_active_visual()
-            self.state.rendered_source_id = None
-            settings = self.state.settings.get(rendered_before)
-            if settings is not None:
-                settings.dirty = True
+            if changed or current_rendered_id is None:
+                self._release_visual(layer)
+                self._set_rendered_source_id(layer, None)
+                settings = self.state.selected_settings(layer)
+                if settings is not None:
+                    settings.dirty = True
         self._sync_panel_sources()
         self._sync_panel_settings()
         self._emit_state()
 
-    def select_source(self, source_id: object) -> None:
-        if self.state.busy:
+    def select_source(
+        self,
+        source_id: object,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        if self.state.busy or self.state.overlay_busy:
             self._cancel_pending_preparation("3D layer changed; click Update.")
         normalized = source_id if isinstance(source_id, str) else None
-        rendered_source_id = self.state.rendered_source_id
+        rendered_source_id = self._rendered_source_id(layer)
+        previous_overlay_selection = self.state.overlay_selected_source_id
         try:
-            self.state.select_source(normalized)
+            self.state.select_source(normalized, layer)
         except ValueError as exc:
-            self._set_error(str(exc))
+            self._set_error(str(exc), layer)
             return
         if rendered_source_id is not None and normalized != rendered_source_id:
-            self._release_active_visual()
-            self.state.rendered_source_id = None
-            self.state.prepared_shape = None
-            self.state.downsample_stride = None
+            self._release_visual(layer)
+            self._set_rendered_source_id(layer, None)
+            self._clear_prepared_status(layer)
+            if layer == RENDER_LAYER_OVERLAY:
+                self.state.overlay_active = False
+        settings = self.state.selected_settings(layer)
+        if settings is not None:
+            settings.dirty = True
+        if (
+            layer == RENDER_LAYER_BASE
+            and previous_overlay_selection is not None
+            and self.state.overlay_selected_source_id is None
+        ):
+            self._release_visual(RENDER_LAYER_OVERLAY)
+            self._clear_prepared_status(RENDER_LAYER_OVERLAY)
+            self.state.overlay_active = False
+        self._sync_panel_sources()
         self._sync_panel_settings()
+        if self._panel is not None:
+            if layer == RENDER_LAYER_OVERLAY:
+                self._panel.set_status(
+                    "Choose a 3D overlay and click Update."
+                    if normalized is None
+                    else "3D overlay changed; click Update."
+                )
+            else:
+                self._panel.set_status("3D layer changed; click Update.")
         self._emit_state()
 
     def set_active(self, active: bool) -> None:
@@ -540,11 +619,19 @@ class Volume3DWidget(QWidget):
         was_active = self.state.active
         self._job_token += 1
         self.state.busy = False
+        self.state.overlay_busy = False
         self.state.active = False
+        self.state.overlay_active = False
         self.state.rendered_source_id = None
+        self.state.overlay_rendered_source_id = None
         self.state.prepared_shape = None
         self.state.downsample_stride = None
+        self.state.overlay_prepared_shape = None
+        self.state.overlay_downsample_stride = None
         self._prepared = None
+        self._overlay_prepared = None
+        self._pending_update_layers.clear()
+        self._preparing_layer = None
         self._destroy_canvas()
         self.placeholder.setText("3D view inactive")
         self.placeholder.setVisible(True)
@@ -556,26 +643,138 @@ class Volume3DWidget(QWidget):
         if was_active:
             self.active_changed.emit(False)
 
-    def update_selected_render(self) -> None:
+    def set_overlay_active(self, active: bool) -> None:
+        if not active:
+            self.dismiss_overlay()
+            return
+        if (
+            not self.state.active
+            or self.state.overlay_rendered_source_id is None
+            or self._overlay_visual is None
+        ):
+            self.state.overlay_active = False
+            self._set_error(
+                "Select and update a 3D overlay before showing it.",
+                RENDER_LAYER_OVERLAY,
+            )
+            return
+        self.state.overlay_active = True
+        self.state.overlay_last_error = None
+        settings = self.state.selected_settings(RENDER_LAYER_OVERLAY)
+        self._overlay_visual.visible = (
+            True if settings is None else settings.visible
+        )
+        if self._overlay_depth_reset_visual is not None:
+            self._overlay_depth_reset_visual.visible = (
+                self._overlay_visual.visible
+            )
+        self._request_canvas_update()
+        if self._panel is not None:
+            self._panel.set_status("3D overlay shown.")
+        self._emit_state()
+
+    def dismiss_overlay(self) -> None:
+        self._cancel_layer_preparation(RENDER_LAYER_OVERLAY)
+        self.state.overlay_active = False
+        if self._overlay_visual is not None:
+            self._overlay_visual.visible = False
+            if self._overlay_depth_reset_visual is not None:
+                self._overlay_depth_reset_visual.visible = False
+            self._request_canvas_update()
+        if self._panel is not None:
+            self._panel.set_status("3D overlay hidden.")
+        self._emit_state()
+
+    def update_dirty_renders(self) -> None:
+        layers: list[str] = []
+        base_settings = self.state.selected_settings(RENDER_LAYER_BASE)
+        if base_settings is not None and (
+            base_settings.dirty or self.state.rendered_source_id is None
+        ):
+            layers.append(RENDER_LAYER_BASE)
+        overlay_settings = self.state.selected_settings(RENDER_LAYER_OVERLAY)
+        if (
+            overlay_settings is not None
+            and (
+                overlay_settings.dirty
+                or self.state.overlay_rendered_source_id is None
+            )
+        ):
+            layers.append(RENDER_LAYER_OVERLAY)
+        if not layers:
+            if (
+                overlay_settings is not None
+                and self.state.overlay_rendered_source_id
+                == self.state.overlay_selected_source_id
+                and not self.state.overlay_active
+            ):
+                self.set_overlay_active(True)
+                return
+            if self._panel is not None:
+                self._panel.set_status(
+                    "Choose a 3D overlay and click Update."
+                    if self.state.overlay_selected_source_id is None
+                    else "3D render is up to date."
+                )
+            return
+        self._queue_render_updates(layers)
+
+    def update_selected_render(
+        self,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        self._queue_render_updates([layer])
+
+    def _queue_render_updates(self, layers: list[str]) -> None:
         if not self.state.active:
             self.set_active(True)
         if not self.state.active:
             return
-        source = self.state.selected_source()
-        settings = self.state.selected_settings()
+        normalized_layers = list(dict.fromkeys(layers))
+        if RENDER_LAYER_OVERLAY in normalized_layers:
+            if self.state.overlay_selected_source_id is None:
+                self._release_visual(RENDER_LAYER_OVERLAY)
+                self.state.overlay_active = False
+                self._set_rendered_source_id(RENDER_LAYER_OVERLAY, None)
+                self._clear_prepared_status(RENDER_LAYER_OVERLAY)
+                if self._panel is not None:
+                    self._panel.set_status(
+                        "Choose a 3D overlay and click Update."
+                    )
+                self._emit_state()
+                normalized_layers.remove(RENDER_LAYER_OVERLAY)
+        if not normalized_layers:
+            return
+        self._cancel_pending_preparation("Preparing 3D render…")
+        self._pending_update_layers = normalized_layers
+        self._start_next_preparation()
+
+    def _start_next_preparation(self) -> None:
+        if not self._pending_update_layers:
+            self._preparing_layer = None
+            if self._panel is not None:
+                self._panel.set_busy(False)
+            return
+        layer = self._pending_update_layers.pop(0)
+        source = self.state.selected_source(layer)
+        settings = self.state.selected_settings(layer)
         if source is None or settings is None:
-            self._set_error("Load an image or segmentation before rendering.")
+            self._set_error(
+                "Load a 3D layer before rendering.",
+                layer,
+            )
             return
 
         self._job_token += 1
         token = self._job_token
+        self._preparing_layer = layer
         worker = _PreparationWorker(
             token,
             source,
             settings.render_mode,
             settings.threshold,
             (
-                self.state.selected_mask_source()
+                self.state.selected_mask_source(layer)
                 if render_mode_supports_mask(
                     source.kind,
                     settings.render_mode,
@@ -586,65 +785,116 @@ class Volume3DWidget(QWidget):
         self._workers[token] = worker
         worker.signals.finished.connect(self._on_preparation_finished)
         worker.signals.failed.connect(self._on_preparation_failed)
-        self.state.busy = True
-        self.state.last_error = None
+        self._set_layer_busy(layer, True)
+        self._set_layer_error(layer, None)
         if self._panel is not None:
             self._panel.set_busy(True)
-            self._panel.set_progress(10, "Preparing and downsampling 3D layer…")
+            layer_name = "overlay" if layer == RENDER_LAYER_OVERLAY else "base layer"
+            self._panel.set_progress(
+                10,
+                f"Preparing and downsampling 3D {layer_name}…",
+            )
         self.render_started.emit()
         self._emit_state()
         self._thread_pool.start(worker)
 
-    def set_selected_visibility(self, visible: bool) -> None:
-        settings = self.state.selected_settings()
+    def set_selected_visibility(
+        self,
+        visible: bool,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
         if settings is None:
             return
         settings.visible = bool(visible)
         if (
-            self.state.selected_source_id == self.state.rendered_source_id
-            and self._active_visual is not None
+            self._selected_source_id(layer) == self._rendered_source_id(layer)
+            and self._visual(layer) is not None
         ):
-            self._active_visual.visible = settings.visible
+            self._visual(layer).visible = settings.visible and (
+                layer == RENDER_LAYER_BASE or self.state.overlay_active
+            )
+            if (
+                layer == RENDER_LAYER_OVERLAY
+                and self._overlay_depth_reset_visual is not None
+            ):
+                self._overlay_depth_reset_visual.visible = (
+                    self._visual(layer).visible
+                )
             self._request_canvas_update()
         self._emit_state()
 
-    def set_selected_opacity(self, opacity: float) -> None:
-        settings = self.state.selected_settings()
+    def set_selected_opacity(
+        self,
+        opacity: float,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
         if settings is None:
             return
         settings.set_opacity(opacity)
-        self._apply_active_style()
+        self._apply_active_style(layer)
         self._emit_state()
 
-    def set_selected_colour(self, colour: object) -> None:
-        settings = self.state.selected_settings()
+    def set_selected_colour(
+        self,
+        colour: object,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
         if settings is None or not isinstance(colour, tuple):
             return
         settings.set_colour(colour)
-        self._apply_active_style()
+        self._apply_active_style(layer)
         self._emit_state()
 
-    def set_selected_node_size(self, node_size: int) -> None:
-        settings = self.state.selected_settings()
+    def set_selected_label_colour(
+        self,
+        label: int,
+        colour: object,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
+        if settings is None or not isinstance(colour, tuple):
+            return
+        settings.set_label_colour(label, colour)
+        self._apply_active_style(layer)
+        self._sync_panel_settings()
+        self._emit_state()
+
+    def set_selected_node_size(
+        self,
+        node_size: int,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
         if settings is None:
             return
         settings.set_node_size(node_size)
-        self._apply_active_style()
+        self._apply_active_style(layer)
         self._sync_panel_settings()
         self._emit_state()
 
-    def set_selected_edge_thickness(self, edge_thickness: int) -> None:
-        settings = self.state.selected_settings()
+    def set_selected_edge_thickness(
+        self,
+        edge_thickness: int,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
         if settings is None:
             return
         settings.set_edge_thickness(edge_thickness)
-        self._apply_active_style()
+        self._apply_active_style(layer)
         self._sync_panel_settings()
         self._emit_state()
 
-    def set_selected_render_mode(self, render_mode: str) -> None:
-        source = self.state.selected_source()
-        settings = self.state.selected_settings()
+    def set_selected_render_mode(
+        self,
+        render_mode: str,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        source = self.state.selected_source(layer)
+        settings = self.state.selected_settings(layer)
         if source is None or settings is None:
             return
         allowed = (
@@ -659,7 +909,7 @@ class Volume3DWidget(QWidget):
         if render_mode not in allowed:
             return
         if settings.render_mode != render_mode:
-            if self.state.busy:
+            if self.state.busy or self.state.overlay_busy:
                 self._cancel_pending_preparation(
                     "Render mode changed; click Update."
                 )
@@ -670,25 +920,30 @@ class Volume3DWidget(QWidget):
             self._panel.set_status("Update required.")
         self._emit_state()
 
-    def set_selected_mask_source(self, mask_source_id: object) -> None:
-        settings = self.state.selected_settings()
+    def set_selected_mask_source(
+        self,
+        mask_source_id: object,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
         if settings is None:
             return
         normalized = mask_source_id if isinstance(mask_source_id, str) else None
         compatible_ids = {
             source.id
             for source in self.state.compatible_masks_for(
-                self.state.selected_source_id
+                self._selected_source_id(layer)
             )
         }
         if normalized is not None and normalized not in compatible_ids:
             self._set_error(
                 "3D render mask is unavailable or spatially incompatible: "
-                f"{normalized}"
+                f"{normalized}",
+                layer,
             )
             return
         if settings.mask_source_id != normalized:
-            if self.state.busy:
+            if self.state.busy or self.state.overlay_busy:
                 self._cancel_pending_preparation(
                     "3D render mask changed; click Update."
                 )
@@ -699,13 +954,17 @@ class Volume3DWidget(QWidget):
             self._panel.set_status("Update required.")
         self._emit_state()
 
-    def set_selected_threshold(self, threshold: float) -> None:
-        settings = self.state.selected_settings()
+    def set_selected_threshold(
+        self,
+        threshold: float,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        settings = self.state.selected_settings(layer)
         if settings is None:
             return
         value = float(threshold)
         if settings.threshold != value:
-            if self.state.busy:
+            if self.state.busy or self.state.overlay_busy:
                 self._cancel_pending_preparation(
                     "Threshold changed; click Update."
                 )
@@ -715,8 +974,12 @@ class Volume3DWidget(QWidget):
             self._panel.set_status("Update required.")
         self._emit_state()
 
-    def mark_selected_dirty(self, message: str = "Update required.") -> None:
-        self.state.mark_selected_dirty()
+    def mark_selected_dirty(
+        self,
+        message: str = "Update required.",
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        self.state.mark_selected_dirty(layer)
         if self._panel is not None:
             self._panel.set_status(message)
         self._emit_state()
@@ -934,44 +1197,73 @@ class Volume3DWidget(QWidget):
         self._workers.pop(token, None)
         if token != self._job_token or not self.state.active:
             return
-        source_id = self.state.selected_source_id
-        settings = self.state.selected_settings()
+        layer = self._preparing_layer or RENDER_LAYER_BASE
+        source_id = self._selected_source_id(layer)
+        settings = self.state.selected_settings(layer)
         if source_id is None or settings is None:
             return
         try:
             if self._panel is not None:
-                self._panel.set_progress(85, "Uploading 3D layer to the GPU…")
-            self._release_active_visual()
-            self._prepared = prepared
-            self._active_visual = self._create_visual(prepared, settings)
+                layer_name = (
+                    "overlay" if layer == RENDER_LAYER_OVERLAY else "base layer"
+                )
+                self._panel.set_progress(
+                    85,
+                    f"Uploading 3D {layer_name} to the GPU…",
+                )
+            self._release_visual(layer)
+            self._set_prepared(layer, prepared)
+            self._set_visual(
+                layer,
+                self._create_visual(prepared, settings, layer),
+            )
         except Exception as exc:
             self._on_preparation_failed(token, f"GPU upload failed: {exc}")
             return
 
-        self.state.rendered_source_id = source_id
-        self.state.prepared_shape = prepared.prepared_shape
-        self.state.downsample_stride = prepared.stride
-        self.state.busy = False
+        self._set_rendered_source_id(layer, source_id)
+        self._set_prepared_status(layer, prepared)
+        self._set_layer_busy(layer, False)
+        if layer == RENDER_LAYER_OVERLAY:
+            self.state.overlay_active = True
+            visual = self._visual(layer)
+            if visual is not None:
+                visual.visible = settings.visible
+            if self._overlay_depth_reset_visual is not None:
+                self._overlay_depth_reset_visual.visible = settings.visible
         settings.dirty = False
         if self._panel is not None:
-            self._panel.set_busy(False)
             self._panel.set_status(
-                "3D layer ready"
+                (
+                    "3D overlay ready"
+                    if layer == RENDER_LAYER_OVERLAY
+                    else "3D layer ready"
+                )
                 if prepared.stride == (1, 1, 1)
-                else f"3D layer ready (overview stride {prepared.stride[0]})."
+                else (
+                    "3D overlay ready"
+                    if layer == RENDER_LAYER_OVERLAY
+                    else "3D layer ready"
+                )
+                + f" (overview stride {prepared.stride[0]})."
             )
-        self.reset_camera()
+        if layer == RENDER_LAYER_BASE:
+            self.reset_camera()
         payload = self.status()
         self.render_finished.emit(payload)
         self._emit_state()
+        self._start_next_preparation()
 
     @Slot(int, str)
     def _on_preparation_failed(self, token: int, message: str) -> None:
         self._workers.pop(token, None)
         if token != self._job_token:
             return
-        self.state.busy = False
-        self._set_error(message)
+        layer = self._preparing_layer or RENDER_LAYER_BASE
+        self._set_layer_busy(layer, False)
+        self._pending_update_layers.clear()
+        self._preparing_layer = None
+        self._set_error(message, layer)
         if self._panel is not None:
             self._panel.set_busy(False)
 
@@ -1025,7 +1317,8 @@ class Volume3DWidget(QWidget):
                 )
 
     def _destroy_canvas(self) -> None:
-        self._release_active_visual()
+        self._release_visual(RENDER_LAYER_BASE)
+        self._release_visual(RENDER_LAYER_OVERLAY)
         if self._view is not None:
             self._view.scene.transform.changed.disconnect(
                 self._on_scene_transform_changed
@@ -1053,26 +1346,48 @@ class Volume3DWidget(QWidget):
         self._view = None
 
     def _release_active_visual(self) -> None:
-        if self._active_visual is not None:
-            self._active_visual.parent = None
-        self._active_visual = None
-        self._active_graph_visuals = {}
-        self._prepared = None
+        """Backward-compatible alias for releasing the base visual."""
+        self._release_visual(RENDER_LAYER_BASE)
 
-    def _create_visual(self, prepared: PreparedRender3D, settings: Any) -> Any:
+    def _release_visual(self, layer: str) -> None:
+        visual = self._visual(layer)
+        if visual is not None:
+            visual.parent = None
+        self._set_visual(layer, None)
+        if layer == RENDER_LAYER_BASE:
+            self._active_graph_visuals = {}
+            self._prepared = None
+        else:
+            if self._overlay_depth_reset_visual is not None:
+                self._overlay_depth_reset_visual.parent = None
+                self._overlay_depth_reset_visual = None
+            self._overlay_graph_visuals = {}
+            self._overlay_prepared = None
+
+    def _create_visual(
+        self,
+        prepared: PreparedRender3D,
+        settings: Any,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> Any:
         if self._view is None:
             raise RuntimeError("3D scene is not initialized.")
         from vispy import scene
         from vispy.visuals.transforms import MatrixTransform
 
         rgba = _rgba(settings.colour, settings.opacity)
+        graph_visuals = (
+            self._active_graph_visuals
+            if layer == RENDER_LAYER_BASE
+            else self._overlay_graph_visuals
+        )
         if prepared.kind == "vessel_graph":
             parent = scene.Node(parent=self._view.scene)
             if (
                 prepared.graph_edge_segments is not None
                 and prepared.graph_edge_segments.size
             ):
-                self._active_graph_visuals["edges"] = scene.visuals.Line(
+                graph_visuals["edges"] = scene.visuals.Line(
                     pos=prepared.graph_edge_segments,
                     connect="segments",
                     color=_rgba(VESSEL_EDGE_COLOR, settings.opacity),
@@ -1090,7 +1405,7 @@ class Volume3DWidget(QWidget):
                     edge_width=0,
                     size=float(settings.node_size * 2),
                 )
-                self._active_graph_visuals["nodes"] = nodes
+                graph_visuals["nodes"] = nodes
             if (
                 prepared.graph_intercept_positions is not None
                 and prepared.graph_intercept_positions.size
@@ -1102,7 +1417,7 @@ class Volume3DWidget(QWidget):
                     edge_width=0,
                     size=float(settings.node_size * 2),
                 )
-                self._active_graph_visuals["intercepts"] = intercepts
+                graph_visuals["intercepts"] = intercepts
             visual = parent
         elif prepared.kind == "image":
             _require_pyopengl_3d_textures()
@@ -1147,7 +1462,7 @@ class Volume3DWidget(QWidget):
             visual = scene.visuals.Markers(parent=self._view.scene)
             visual.set_data(
                 prepared.vertices,
-                face_color=rgba,
+                face_color=_segmentation_vertex_colours(prepared, settings),
                 edge_width=0,
                 size=4,
             )
@@ -1157,45 +1472,86 @@ class Volume3DWidget(QWidget):
             visual = scene.visuals.Mesh(
                 vertices=prepared.vertices,
                 faces=prepared.faces,
-                color=rgba,
+                vertex_colors=_segmentation_vertex_colours(
+                    prepared,
+                    settings,
+                ),
                 shading="smooth",
                 parent=self._view.scene,
             )
         visual.visible = settings.visible
+        if layer == RENDER_LAYER_OVERLAY:
+            self._ensure_overlay_depth_reset()
+            visual.order = 1
         return visual
 
-    def _apply_active_style(self) -> None:
+    def _ensure_overlay_depth_reset(self) -> None:
+        """Clear base-pass depth before drawing the alpha-composited overlay."""
+        if self._overlay_depth_reset_visual is not None:
+            self._overlay_depth_reset_visual.visible = True
+            return
+        if self._view is None:
+            raise RuntimeError("3D scene is not initialized.")
+        from vispy import gloo, scene
+        from vispy.visuals import Visual
+
+        class _OverlayDepthResetVisual(Visual):
+            def _prepare_transforms(self, view: Any) -> None:
+                return
+
+            def draw(self) -> None:
+                if self.visible:
+                    gloo.set_depth_mask(True)
+                    gloo.clear(color=False, depth=True, stencil=False)
+
+        depth_reset_node = scene.visuals.create_visual_node(
+            _OverlayDepthResetVisual
+        )(parent=self._view.scene)
+        depth_reset_node.order = 0.5
+        self._overlay_depth_reset_visual = depth_reset_node
+
+    def _apply_active_style(
+        self,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        visual = self._visual(layer)
+        prepared = self._prepared_for_layer(layer)
         if (
-            self._active_visual is None
-            or self._prepared is None
-            or self.state.selected_source_id != self.state.rendered_source_id
+            visual is None
+            or prepared is None
+            or self._selected_source_id(layer) != self._rendered_source_id(layer)
         ):
             return
-        settings = self.state.selected_settings()
+        settings = self.state.selected_settings(layer)
         if settings is None:
             return
         rgba = _rgba(settings.colour, settings.opacity)
-        if self._prepared.kind == "vessel_graph":
-            edges = self._active_graph_visuals.get("edges")
+        graph_visuals = (
+            self._active_graph_visuals
+            if layer == RENDER_LAYER_BASE
+            else self._overlay_graph_visuals
+        )
+        if prepared.kind == "vessel_graph":
+            edges = graph_visuals.get("edges")
             if edges is not None:
                 edges.set_data(
-                    pos=self._prepared.graph_edge_segments,
+                    pos=prepared.graph_edge_segments,
                     connect="segments",
                     color=_rgba(VESSEL_EDGE_COLOR, settings.opacity),
                     width=float(settings.edge_thickness),
                 )
-            nodes = self._active_graph_visuals.get("nodes")
+            nodes = graph_visuals.get("nodes")
             if nodes is not None:
                 nodes.set_data(
-                    self._prepared.graph_node_positions,
+                    prepared.graph_node_positions,
                     face_color=_rgba(VESSEL_NODE_COLOR, settings.opacity),
                     edge_width=0,
                     size=float(settings.node_size * 2),
                 )
-            intercepts = self._active_graph_visuals.get("intercepts")
+            intercepts = graph_visuals.get("intercepts")
             if intercepts is not None:
                 intercepts.set_data(
-                    self._prepared.graph_intercept_positions,
+                    prepared.graph_intercept_positions,
                     face_color=_rgba(
                         PROJECTED_INTERCEPT_COLOR,
                         settings.opacity,
@@ -1203,30 +1559,37 @@ class Volume3DWidget(QWidget):
                     edge_width=0,
                     size=float(settings.node_size * 2),
                 )
-        elif self._prepared.kind == "image":
+        elif prepared.kind == "image":
             cutoff = _normalized_threshold(
                 settings.threshold,
-                self._prepared.source_range,
+                prepared.source_range,
             )
-            self._active_visual.cmap = _volume_colormap(
+            visual.cmap = _volume_colormap(
                 settings.colour,
                 settings.opacity,
-                translucent=self._prepared.render_mode == "Translucent",
+                translucent=prepared.render_mode == "Translucent",
                 cutoff=cutoff,
                 masked_minip=(
-                    self._prepared.mask_applied
-                    and self._prepared.render_mode == "MinIP"
+                    prepared.mask_applied
+                    and prepared.render_mode == "MinIP"
                 ),
             )
-        elif self._prepared.render_mode == "Points":
-            self._active_visual.set_data(
-                self._prepared.vertices,
-                face_color=rgba,
+        elif prepared.render_mode == "Points":
+            visual.set_data(
+                prepared.vertices,
+                face_color=_segmentation_vertex_colours(prepared, settings),
                 edge_width=0,
                 size=4,
             )
         else:
-            self._active_visual.color = rgba
+            visual.set_data(
+                vertices=prepared.vertices,
+                faces=prepared.faces,
+                vertex_colors=_segmentation_vertex_colours(
+                    prepared,
+                    settings,
+                ),
+            )
         self._request_canvas_update()
 
     def _refresh_patch_visual(self) -> None:
@@ -1526,56 +1889,208 @@ class Volume3DWidget(QWidget):
             ],
             self.state.selected_source_id,
         )
+        self._panel.set_overlay_sources(
+            [
+                (source.id, source.display_name)
+                for source in self.state.overlay_sources()
+            ],
+            self.state.overlay_selected_source_id,
+        )
 
     def _sync_panel_settings(self) -> None:
         if self._panel is None:
             return
-        source = self.state.selected_source()
-        settings = self.state.selected_settings()
+        source = self.state.selected_source(RENDER_LAYER_BASE)
+        settings = self.state.selected_settings(RENDER_LAYER_BASE)
         if source is None or settings is None:
             self._panel.set_source_kind(None)
             self._panel.set_modes((), "")
             self._panel.set_masks((), None)
             self._panel.set_status("Load an image before rendering.")
             self._panel.set_render_controls_enabled(False)
-            return
-        modes = (
-            RAW_RENDER_MODES
-            if source.kind == "image"
-            else (
-                SEGMENTATION_RENDER_MODES
-                if source.kind == "segmentation"
-                else VESSEL_GRAPH_RENDER_MODES
+        else:
+            modes = (
+                RAW_RENDER_MODES
+                if source.kind == "image"
+                else (
+                    SEGMENTATION_RENDER_MODES
+                    if source.kind == "segmentation"
+                    else VESSEL_GRAPH_RENDER_MODES
+                )
             )
+            self._panel.set_source_kind(source.kind)
+            self._panel.set_modes(modes, settings.render_mode)
+            self._panel.set_masks(
+                [
+                    (mask_source.id, mask_source.display_name)
+                    for mask_source in self.state.compatible_masks_for(
+                        self.state.selected_source_id
+                    )
+                ],
+                settings.mask_source_id,
+            )
+            self._panel.set_settings(settings)
+            labels: tuple[int, ...] = ()
+            if source.kind == "segmentation" and source.volume is not None:
+                try:
+                    labels = segmentation_labels(source.volume)
+                except ValueError:
+                    labels = ()
+            self._panel.set_label_colours(labels, settings)
+            self._panel.set_render_controls_enabled(self.state.active)
+
+        overlay_source = self.state.selected_source(RENDER_LAYER_OVERLAY)
+        overlay_settings = self.state.selected_settings(RENDER_LAYER_OVERLAY)
+        if overlay_source is None or overlay_settings is None:
+            self._panel.set_overlay_source_kind(None)
+            self._panel.set_overlay_modes((), "")
+            self._panel.set_overlay_masks((), None)
+            return
+        overlay_modes = (
+            SEGMENTATION_RENDER_MODES
+            if overlay_source.kind == "segmentation"
+            else VESSEL_GRAPH_RENDER_MODES
         )
-        self._panel.set_source_kind(source.kind)
-        self._panel.set_modes(modes, settings.render_mode)
-        self._panel.set_masks(
+        self._panel.set_overlay_source_kind(overlay_source.kind)
+        self._panel.set_overlay_modes(
+            overlay_modes,
+            overlay_settings.render_mode,
+        )
+        self._panel.set_overlay_masks(
             [
                 (mask_source.id, mask_source.display_name)
                 for mask_source in self.state.compatible_masks_for(
-                    self.state.selected_source_id
+                    self.state.overlay_selected_source_id
                 )
             ],
-            settings.mask_source_id,
+            overlay_settings.mask_source_id,
         )
-        self._panel.set_settings(settings)
-        self._panel.set_render_controls_enabled(self.state.active)
+        overlay_labels: tuple[int, ...] = ()
+        if (
+            overlay_source.kind == "segmentation"
+            and overlay_source.volume is not None
+        ):
+            try:
+                overlay_labels = segmentation_labels(overlay_source.volume)
+            except ValueError:
+                overlay_labels = ()
+        self._panel.set_overlay_settings(
+            overlay_settings,
+            overlay_labels,
+        )
 
-    def _set_error(self, message: str) -> None:
-        self.state.last_error = str(message)
+    def _set_error(
+        self,
+        message: str,
+        layer: str = RENDER_LAYER_BASE,
+    ) -> None:
+        self._set_layer_error(layer, str(message))
         if self._panel is not None:
             self._panel.set_status(str(message))
-        self.placeholder.setText(str(message))
+        if layer == RENDER_LAYER_BASE:
+            self.placeholder.setText(str(message))
         self.render_failed.emit(str(message))
         self._emit_state()
 
     def _cancel_pending_preparation(self, message: str) -> None:
         self._job_token += 1
         self.state.busy = False
+        self.state.overlay_busy = False
+        self._preparing_layer = None
+        self._pending_update_layers.clear()
         if self._panel is not None:
             self._panel.set_busy(False)
             self._panel.set_status(message)
+
+    def _cancel_layer_preparation(self, layer: str) -> None:
+        if self._preparing_layer == layer or layer in self._pending_update_layers:
+            self._cancel_pending_preparation("3D render update canceled.")
+
+    def _selected_source_id(self, layer: str) -> str | None:
+        return (
+            self.state.selected_source_id
+            if layer == RENDER_LAYER_BASE
+            else self.state.overlay_selected_source_id
+        )
+
+    def _rendered_source_id(self, layer: str) -> str | None:
+        return (
+            self.state.rendered_source_id
+            if layer == RENDER_LAYER_BASE
+            else self.state.overlay_rendered_source_id
+        )
+
+    def _set_rendered_source_id(
+        self,
+        layer: str,
+        source_id: str | None,
+    ) -> None:
+        if layer == RENDER_LAYER_BASE:
+            self.state.rendered_source_id = source_id
+        else:
+            self.state.overlay_rendered_source_id = source_id
+
+    def _visual(self, layer: str) -> Any | None:
+        return (
+            self._active_visual
+            if layer == RENDER_LAYER_BASE
+            else self._overlay_visual
+        )
+
+    def _set_visual(self, layer: str, visual: Any | None) -> None:
+        if layer == RENDER_LAYER_BASE:
+            self._active_visual = visual
+        else:
+            self._overlay_visual = visual
+
+    def _prepared_for_layer(self, layer: str) -> PreparedRender3D | None:
+        return (
+            self._prepared
+            if layer == RENDER_LAYER_BASE
+            else self._overlay_prepared
+        )
+
+    def _set_prepared(
+        self,
+        layer: str,
+        prepared: PreparedRender3D | None,
+    ) -> None:
+        if layer == RENDER_LAYER_BASE:
+            self._prepared = prepared
+        else:
+            self._overlay_prepared = prepared
+
+    def _set_prepared_status(
+        self,
+        layer: str,
+        prepared: PreparedRender3D,
+    ) -> None:
+        if layer == RENDER_LAYER_BASE:
+            self.state.prepared_shape = prepared.prepared_shape
+            self.state.downsample_stride = prepared.stride
+        else:
+            self.state.overlay_prepared_shape = prepared.prepared_shape
+            self.state.overlay_downsample_stride = prepared.stride
+
+    def _clear_prepared_status(self, layer: str) -> None:
+        if layer == RENDER_LAYER_BASE:
+            self.state.prepared_shape = None
+            self.state.downsample_stride = None
+        else:
+            self.state.overlay_prepared_shape = None
+            self.state.overlay_downsample_stride = None
+
+    def _set_layer_busy(self, layer: str, busy: bool) -> None:
+        if layer == RENDER_LAYER_BASE:
+            self.state.busy = bool(busy)
+        else:
+            self.state.overlay_busy = bool(busy)
+
+    def _set_layer_error(self, layer: str, message: str | None) -> None:
+        if layer == RENDER_LAYER_BASE:
+            self.state.last_error = message
+        else:
+            self.state.overlay_last_error = message
 
     def _emit_state(self) -> None:
         self.state_changed.emit(self.status())
@@ -1595,6 +2110,28 @@ def _rgba(
         colour[2] / 255.0,
         min(max(float(opacity), 0.0), 1.0),
     )
+
+
+def _segmentation_vertex_colours(
+    prepared: PreparedRender3D,
+    settings: Any,
+) -> np.ndarray:
+    vertices = prepared.vertices
+    labels = prepared.vertex_labels
+    if vertices is None:
+        return np.empty((0, 4), dtype=np.float32)
+    if labels is None or labels.shape != (vertices.shape[0],):
+        return np.tile(
+            np.asarray(_rgba(settings.colour, settings.opacity), dtype=np.float32),
+            (vertices.shape[0], 1),
+        )
+    colours = np.empty((vertices.shape[0], 4), dtype=np.float32)
+    for label in np.unique(labels):
+        colours[labels == label] = _rgba(
+            settings.colour_for_label(int(label)),
+            settings.opacity,
+        )
+    return colours
 
 
 def _volume_world_limits(


### PR DESCRIPTION
- Added independent 3D overlays to both main and patch windows.
- Supports one loaded NIfTI segmentation or GraphML overlay, independently of the 2D overlay selection.
- Added separate overlay opacity, render mode, masking, per-label colours, and GraphML display controls.
- Enforced strict NIfTI shape/affine compatibility without automatic resampling; GraphML remains in world coordinates and is clipped in patch windows.
- Added multi-label segmentation rendering with deterministic editable colours and label-data validation.
- Fixed scalar-volume depth clipping so overlays remain visible inside the base volume.
- Extended render3d CLI/controller commands with --layer base|overlay and per-label colour support while preserving base-layer defaults.
- Added version numbers to main and patch window titles.
- Updated 3D overlay and command-layer documentation.
- Main window interface preview:
<img width="1925" height="1090" alt="image" src="https://github.com/user-attachments/assets/299ec2b6-7417-4829-b1ee-4edcd40ae0e9" />
- Patch window interface preview:
<img width="1654" height="1073" alt="image" src="https://github.com/user-attachments/assets/458fdf11-0bc8-46c4-81cd-1e6162b0743a" />


